### PR TITLE
[FEAT] 코스 목록 1안 북마크 낙관적 업데이트 추가

### DIFF
--- a/packages/stack-link/src/components/GoBackTrigger/index.tsx
+++ b/packages/stack-link/src/components/GoBackTrigger/index.tsx
@@ -87,14 +87,34 @@ export default function GoBackTrigger() {
       {portalElement &&
         !isNavigating &&
         createPortal(
-          <div className="fixed w-screen h-screen top-0 left-0 transform-gpu -z-50 select-none" />,
+          <div
+            // className="fixed w-screen h-screen top-0 left-0 transform-gpu -z-50 select-none"
+            style={{
+              position: "fixed",
+              width: "100%",
+              height: "100%",
+              top: 0,
+              left: 0,
+              transform: "translateZ(0)",
+              zIndex: -50,
+              pointerEvents: "none",
+            }}
+          />,
           portalElement,
         )}
 
       {createPortal(
         <div
           id={goBackTriggerElementId}
-          className="fixed w-10 h-screen top-0 transform-gpu select-none z-[9999] -translate-x-1"
+          style={{
+            position: "fixed",
+            width: "2.5rem",
+            height: "100vh",
+            top: 0,
+            left: 0,
+            transform: "translateX(-10%)",
+            zIndex: 9999,
+          }}
           role="button"
           onTouchStart={(e) => {
             e.stopPropagation();

--- a/packages/web/src/api/v1/bookmarks/index.ts
+++ b/packages/web/src/api/v1/bookmarks/index.ts
@@ -1,10 +1,15 @@
 import authenticatedApi from "@/api/_instances/authenticatedApi";
+import { Course } from "@/types/course";
 
 export const BOOKMARK_API_PATH = "api/v1/bookmarks";
 
+interface GetBookmarksResponse {
+  bookmarkList: Course[];
+}
+
 // GET
 export const getBookmarksApi = async () => {
-  const response = await authenticatedApi({
+  const response = await authenticatedApi<GetBookmarksResponse>({
     method: "get",
     url: BOOKMARK_API_PATH,
   });
@@ -14,7 +19,7 @@ export const getBookmarksApi = async () => {
 
 // POST
 export const postBookmarkApi = async (courseId: string) => {
-  const response = await authenticatedApi({
+  const response = await authenticatedApi<null>({
     method: "post",
     url: BOOKMARK_API_PATH,
     data: {

--- a/packages/web/src/api/v1/mountains/[mountainId]/courses/index.ts
+++ b/packages/web/src/api/v1/mountains/[mountainId]/courses/index.ts
@@ -1,24 +1,14 @@
 import authenticatedApi from "@/api/_instances/authenticatedApi";
-import { CourseDifficulty } from "@/types/course";
+import type { Course } from "@/types/course";
 
 export type CourseSortType = "length" | "difficulty";
 
-export const COURSES_OF_MOUNTAIN = (
+export const COURSES_OF_MOUNTAIN_API_PATH = (
   mountainId: string,
-  { searchParams: { sortBy } }: { searchParams: { sortBy: CourseSortType } }
+  { searchParams: { sortBy } }: { searchParams: { sortBy: CourseSortType } },
 ) => `api/v1/mountains/${mountainId}/courses?sort=${sortBy}`;
 
-interface Course {
-  id: string;
-  name: string;
-  length: number;
-  duration: number;
-  difficulty: CourseDifficulty;
-  bookmark: boolean;
-  image: string;
-}
-
-interface GetCoursesOfMountainResponse {
+export interface GetCoursesOfMountainResponse {
   courses: Course[];
 }
 
@@ -33,7 +23,7 @@ export const getCoursesOfMountainApi = async ({
 }: GetCoursesOfMountainApiParams) => {
   const response = await authenticatedApi<GetCoursesOfMountainResponse>({
     method: "get",
-    url: COURSES_OF_MOUNTAIN(mountainId, { searchParams: { sortBy } }),
+    url: COURSES_OF_MOUNTAIN_API_PATH(mountainId, { searchParams: { sortBy } }),
   });
 
   return response.data;

--- a/packages/web/src/components/features/widgets/course/CourseListWithBookmarkMutate/index.tsx
+++ b/packages/web/src/components/features/widgets/course/CourseListWithBookmarkMutate/index.tsx
@@ -1,8 +1,10 @@
+import { CourseSortType } from "@/api/v1/mountains/[mountainId]/courses";
 import type { CourseDifficulty } from "@/types/course";
 import useBookmarkMutation from "@hooks/feature/query/mutate/useBookmarkMutation";
 import useDeleteBookmarkMutation from "@hooks/feature/query/mutate/useDeleteBookmarkMutation";
 import CoursePathwayPrefetcher from "@pages/course/CoursePathwayPrefetcher";
 import CourseList from "@shared/ui/CourseList";
+import { useParams, useSearchParams } from "next/navigation";
 
 interface CourseListWithBookmarkMutateProps {
   id: string;
@@ -22,8 +24,17 @@ export default function CourseListWithBookmarkMutate({
   image,
   ...props
 }: CourseListWithBookmarkMutateProps) {
-  const { mutate: postBookmark } = useBookmarkMutation();
-  const { mutate: deleteBookmark } = useDeleteBookmarkMutation();
+  const { mountainId } = useParams<{ mountainId: string }>();
+  const searchParams = useSearchParams();
+
+  const { mutate: postBookmark } = useBookmarkMutation({
+    mountainId,
+    sortBy: searchParams.get("sort") as CourseSortType,
+  });
+  const { mutate: deleteBookmark } = useDeleteBookmarkMutation({
+    mountainId,
+    sortBy: searchParams.get("sort") as CourseSortType,
+  });
 
   return (
     <>

--- a/packages/web/src/hooks/feature/query/mutate/useBookmarkMutation/index.ts
+++ b/packages/web/src/hooks/feature/query/mutate/useBookmarkMutation/index.ts
@@ -1,15 +1,79 @@
 import { BOOKMARK_API_PATH, postBookmarkApi } from "@/api/v1/bookmarks";
+import {
+  COURSES_OF_MOUNTAIN_API_PATH,
+  CourseSortType,
+  GetCoursesOfMountainResponse,
+} from "@/api/v1/mountains/[mountainId]/courses";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-const useBookmarkMutation = () => {
+interface UseBookmarkMutationProps {
+  mountainId: string;
+  sortBy: CourseSortType;
+}
+
+/**
+ * 북마크 추가 Mutation
+ *
+ * 인자로 mountainId, sortBy를 받는 것은 낙관적 업데이트를 위함이다.(올바른 방법인지는 확인 필요)
+ */
+const useBookmarkMutation = ({
+  mountainId,
+  sortBy,
+}: UseBookmarkMutationProps) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationKey: [BOOKMARK_API_PATH],
     mutationFn: postBookmarkApi,
+    onMutate: (selectedCourseId) => {
+      // const prev = queryClient.getQueryData([BOOKMARK_API_PATH]);
+
+      // 코스 리스트 데이터가 들어있다.
+      const prevCourseListData =
+        queryClient.getQueryData<GetCoursesOfMountainResponse>([
+          COURSES_OF_MOUNTAIN_API_PATH(mountainId, {
+            searchParams: { sortBy },
+          }),
+        ]).courses;
+      const newCourseListData = prevCourseListData.map((course) => {
+        if (course.id === selectedCourseId) {
+          return {
+            ...course,
+            bookmark: true,
+          };
+        }
+        return course;
+      });
+
+      queryClient.setQueryData(
+        [
+          COURSES_OF_MOUNTAIN_API_PATH(mountainId, {
+            searchParams: { sortBy },
+          }),
+        ],
+        {
+          courses: newCourseListData,
+        },
+      );
+
+      return prevCourseListData;
+    },
+
     onSuccess: () => {
       // TODO: 낙관적 업데이트로 변경하기
       queryClient.invalidateQueries({ queryKey: [BOOKMARK_API_PATH] });
+    },
+    onError: (_, __, context) => {
+      queryClient.setQueryData(
+        [
+          COURSES_OF_MOUNTAIN_API_PATH(mountainId, {
+            searchParams: { sortBy },
+          }),
+        ],
+        {
+          courses: context,
+        },
+      );
     },
   });
 };

--- a/packages/web/src/hooks/feature/query/mutate/useDeleteBookmarkMutation/index.ts
+++ b/packages/web/src/hooks/feature/query/mutate/useDeleteBookmarkMutation/index.ts
@@ -3,17 +3,77 @@ import {
   DELETE_BOOKMARK_API_PATH,
   deleteBookmarkApi,
 } from "@/api/v1/bookmarks/[courseId]";
+import {
+  COURSES_OF_MOUNTAIN_API_PATH,
+  CourseSortType,
+  type GetCoursesOfMountainResponse,
+} from "@/api/v1/mountains/[mountainId]/courses";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-const useDeleteBookmarkMutation = () => {
+interface UseDeleteBookmarkMutationProps {
+  mountainId: string;
+  sortBy: CourseSortType;
+}
+
+const useDeleteBookmarkMutation = ({
+  mountainId,
+  sortBy,
+}: UseDeleteBookmarkMutationProps) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationKey: [DELETE_BOOKMARK_API_PATH],
     mutationFn: deleteBookmarkApi,
+
+    onMutate: (selectedCourseId) => {
+      // const prev = queryClient.getQueryData([BOOKMARK_API_PATH]);
+
+      // 코스 리스트 데이터가 들어있다.
+      const prevCourseListData =
+        queryClient.getQueryData<GetCoursesOfMountainResponse>([
+          COURSES_OF_MOUNTAIN_API_PATH(mountainId, {
+            searchParams: { sortBy },
+          }),
+        ]).courses;
+      const newCourseListData = prevCourseListData.map((course) => {
+        if (course.id === selectedCourseId) {
+          return {
+            ...course,
+            bookmark: false,
+          };
+        }
+        return course;
+      });
+
+      queryClient.setQueryData(
+        [
+          COURSES_OF_MOUNTAIN_API_PATH(mountainId, {
+            searchParams: { sortBy },
+          }),
+        ],
+        {
+          courses: newCourseListData,
+        },
+      );
+
+      return prevCourseListData;
+    },
+
     onSuccess: () => {
       // TODO: 낙관적 업데이트로 변경하기
       queryClient.invalidateQueries({ queryKey: [BOOKMARK_API_PATH] });
+    },
+    onError: (_, __, context) => {
+      queryClient.setQueryData(
+        [
+          COURSES_OF_MOUNTAIN_API_PATH(mountainId, {
+            searchParams: { sortBy },
+          }),
+        ],
+        {
+          courses: context,
+        },
+      );
     },
   });
 };

--- a/packages/web/src/hooks/feature/query/prefetch/useCoursesOfMountainPrefetch/index.tsx
+++ b/packages/web/src/hooks/feature/query/prefetch/useCoursesOfMountainPrefetch/index.tsx
@@ -1,5 +1,5 @@
 import {
-  COURSES_OF_MOUNTAIN,
+  COURSES_OF_MOUNTAIN_API_PATH,
   CourseSortType,
   getCoursesOfMountainApi,
 } from "@api/v1/mountains/[mountainId]/courses";
@@ -15,7 +15,9 @@ const useCoursesOfMountainPrefetch = ({
   sortBy,
 }: UseCoursesOfMountainPrefetchProps) => {
   return usePrefetchQuery({
-    queryKey: [COURSES_OF_MOUNTAIN(mountainId, { searchParams: { sortBy } })],
+    queryKey: [
+      COURSES_OF_MOUNTAIN_API_PATH(mountainId, { searchParams: { sortBy } }),
+    ],
     queryFn: () => getCoursesOfMountainApi({ mountainId, sortBy }),
     staleTime: 1000 * 60 * 5, // 5m
     gcTime: 1000 * 60 * 60, // 1h

--- a/packages/web/src/hooks/feature/query/query/useCoursesOfMountainQuery/index.tsx
+++ b/packages/web/src/hooks/feature/query/query/useCoursesOfMountainQuery/index.tsx
@@ -1,5 +1,5 @@
 import {
-  COURSES_OF_MOUNTAIN,
+  COURSES_OF_MOUNTAIN_API_PATH,
   CourseSortType,
   getCoursesOfMountainApi,
 } from "@api/v1/mountains/[mountainId]/courses";
@@ -15,7 +15,9 @@ const useCoursesOfMountainQuery = ({
   sortBy,
 }: UseCoursesOfMountainQueryProps) => {
   return useSuspenseQuery({
-    queryKey: [COURSES_OF_MOUNTAIN(mountainId, { searchParams: { sortBy } })],
+    queryKey: [
+      COURSES_OF_MOUNTAIN_API_PATH(mountainId, { searchParams: { sortBy } }),
+    ],
     queryFn: () => getCoursesOfMountainApi({ mountainId, sortBy }),
     staleTime: 1000 * 60 * 5, // 5m
     gcTime: 1000 * 60 * 60, // 1h

--- a/packages/web/src/types/course/index.ts
+++ b/packages/web/src/types/course/index.ts
@@ -1,2 +1,12 @@
 // export type CourseDifficulty = "쉬움" | "보통" | "어려움";
 export type CourseDifficulty = "EASY" | "NORMAL" | "HARD";
+
+export interface Course {
+  id: string;
+  name: string;
+  length: number;
+  duration: number;
+  difficulty: CourseDifficulty;
+  bookmark: boolean;
+  image: string;
+}


### PR DESCRIPTION
- #4 

코스 목록 1안 페이지의 북마크에 낙관적 업데이트를 추가하였습니다. 

<div align="center">
<img width="25%" src="https://github.com/user-attachments/assets/8ed9dde6-3225-4728-a69c-a94eb0ee8c92"/>
</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 코스 북마크/해제 시 목록에 즉시 반영되어 화면이 즉각 업데이트됩니다.
- Bug Fixes
  - 코스 정렬 상태에서 북마크 변경 후에도 목록 상태가 올바르게 유지됩니다.
- Style
  - 뒤로가기 트리거/오버레이 렌더링 방식 개선으로 일부 환경에서 깜빡임이 줄어듭니다.
- Refactor
  - 코스 난이도 표기를 영어(EASY/NORMAL/HARD)로 통일하여 일관성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->