### PR TITLE
[FIX] 산행 결과 스크린에서 올바르게 지도를 위치시키고 줌을 하도록 수정

### DIFF
--- a/packages/app/src/components/feature/screens/travel/TravelResultMapView/index.tsx
+++ b/packages/app/src/components/feature/screens/travel/TravelResultMapView/index.tsx
@@ -19,20 +19,25 @@ const TravelResultMapView = memo(() => {
         : [];
   }, [traveledPaths]);
 
-  const midPoint = {
-    latitude:
-      traveledPath.length > 0
-        ? (Math.max(...traveledPath.map(([, latitude]) => latitude)) +
-            Math.min(...traveledPath.map(([, latitude]) => latitude))) /
-          2
-        : 0,
-    longitude:
-      traveledPath.length > 0
-        ? (Math.max(...traveledPath.map(([longitude]) => longitude)) +
-            Math.min(...traveledPath.map(([longitude]) => longitude))) /
-          2
-        : 0,
-  };
+  const midPoint = useMemo(() => {
+    if (traveledPath.length === 0) return { latitude: 0, longitude: 0 };
+
+    const latitudes = traveledPath.map(([, latitude]) => latitude);
+    const longitudes = traveledPath.map(([longitude]) => longitude);
+
+    const centerLat = (Math.max(...latitudes) + Math.min(...latitudes)) / 2;
+    const centerLng = (Math.max(...longitudes) + Math.min(...longitudes)) / 2;
+
+    const latRange = Math.max(...latitudes) - Math.min(...latitudes);
+
+    const offsetFactor = 0.4;
+    const latOffset = latRange * offsetFactor;
+
+    return {
+      latitude: centerLat - latOffset,
+      longitude: centerLng,
+    };
+  }, [traveledPath]);
 
   const zoomLevel = useMemo(() => {
     if (traveledPath.length === 0) return 15;
@@ -43,15 +48,15 @@ const TravelResultMapView = memo(() => {
     const latitudeDiff = Math.max(...latitudes) - Math.min(...latitudes);
     const longitudeDiff = Math.max(...longitudes) - Math.min(...longitudes);
 
-    const paddedLatDiff = latitudeDiff * 1.15;
-    const paddedLngDiff = longitudeDiff * 1.15;
+    const paddedLatDiff = latitudeDiff * 25001; // 세로 패딩
+    const paddedLngDiff = longitudeDiff * 25001; // 가로 패딩
 
-    const maxDiff = Math.max(paddedLatDiff, paddedLngDiff);
+    const latZoom = Math.max(1, 22 - Math.log2(paddedLatDiff));
+    const lngZoom = Math.max(1, 22 - Math.log2(paddedLngDiff));
 
-    return Math.min(
-      20,
-      Math.max(13, Math.max(1, 24 - Math.log2(maxDiff * 111000))),
-    );
+    const zoom = Math.min(latZoom, lngZoom);
+
+    return Math.min(20, Math.max(1, zoom));
   }, [traveledPath]);
 
   useEffect(() => {

--- a/packages/app/src/components/feature/screens/travel/TravelResultMapView/index.tsx
+++ b/packages/app/src/components/feature/screens/travel/TravelResultMapView/index.tsx
@@ -3,8 +3,6 @@ import { COLORS } from "@styles/colorPalette";
 import ConfigurableMapView from "@widget/ConfigurableMapView";
 import { memo, useEffect, useMemo } from "react";
 
-const ZOOM_LEVEL = 14;
-
 const TravelResultMapView = memo(() => {
   const { traveledPath, reset } = useTravelStateStore();
 
@@ -12,6 +10,7 @@ const TravelResultMapView = memo(() => {
     latitude,
     longitude,
   }));
+
   const basePoints = useMemo(() => {
     return traveledPaths.length >= 2
       ? [traveledPaths[0], traveledPaths[traveledPaths.length - 1]]
@@ -23,15 +22,37 @@ const TravelResultMapView = memo(() => {
   const midPoint = {
     latitude:
       traveledPath.length > 0
-        ? traveledPath.reduce((acc, cur) => acc + Number(cur[1]), 0) /
-          traveledPath.length
+        ? (Math.max(...traveledPath.map(([, latitude]) => latitude)) +
+            Math.min(...traveledPath.map(([, latitude]) => latitude))) /
+          2
         : 0,
     longitude:
       traveledPath.length > 0
-        ? traveledPath.reduce((acc, cur) => acc + Number(cur[0]), 0) /
-          traveledPath.length
+        ? (Math.max(...traveledPath.map(([longitude]) => longitude)) +
+            Math.min(...traveledPath.map(([longitude]) => longitude))) /
+          2
         : 0,
   };
+
+  const zoomLevel = useMemo(() => {
+    if (traveledPath.length === 0) return 15;
+
+    const latitudes = traveledPath.map(([, latitude]) => latitude);
+    const longitudes = traveledPath.map(([longitude]) => longitude);
+
+    const latitudeDiff = Math.max(...latitudes) - Math.min(...latitudes);
+    const longitudeDiff = Math.max(...longitudes) - Math.min(...longitudes);
+
+    const paddedLatDiff = latitudeDiff * 1.15;
+    const paddedLngDiff = longitudeDiff * 1.15;
+
+    const maxDiff = Math.max(paddedLatDiff, paddedLngDiff);
+
+    return Math.min(
+      20,
+      Math.max(13, Math.max(1, 24 - Math.log2(maxDiff * 111000))),
+    );
+  }, [traveledPath]);
 
   useEffect(() => {
     return () => {
@@ -46,6 +67,7 @@ const TravelResultMapView = memo(() => {
           coords: traveledPaths,
           color: COLORS.primary,
           width: 6,
+          outlineWidth: 0,
         },
       ]}
       currentPositionIcon={false}
@@ -53,15 +75,19 @@ const TravelResultMapView = memo(() => {
         initialCamera: {
           latitude: midPoint.latitude,
           longitude: midPoint.longitude,
-          zoom: ZOOM_LEVEL,
+          zoom: zoomLevel,
         },
-        maxZoom: ZOOM_LEVEL + 0.01,
-        minZoom: ZOOM_LEVEL - 0.01,
+        maxZoom: zoomLevel + 0.01,
+        minZoom: zoomLevel - 0.01,
         isRotateGesturesEnabled: false, // 회전 제스처 비활성화
         isTiltGesturesEnabled: false, // 기울기 제스처 비활성화
         isScrollGesturesEnabled: false, // 스크롤 제스처 비활성화
         isZoomGesturesEnabled: false, // 줌 제스처 비활성화
         isLiteModeEnabled: true, // 라이트 모드 활성화 (성능 향상)
+        logoAlign: "BottomLeft",
+        logoMargin: {
+          bottom: 250,
+        },
       }}
       basePoints={basePoints}
     />


### PR DESCRIPTION
- #15

## 주요 변경 사항

산행 결과 스크린에서 올바르게 지도를 위치시키고 줌을 하도록 수정하였습니다.
지도의 위치는 위경도의 최대/최소값의 평균값(정확히 중앙값)으로 설정하였습니다.
줌 레벨의 경우 올바른 식을 도입하여 사용자가 이동한 경로가 지도에 잘 보이도록 하였습니다. 

<div align="center">
  <div>
    <img width="25%" src="https://github.com/user-attachments/assets/10c7f631-dd82-4090-a82c-a86d811fe034"/>
    <img width="25%" src="https://github.com/user-attachments/assets/2f960a05-6c5b-4bdd-9028-c53ddf844be8"/>
  </div>
</div>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 경로 분포에 따른 자동 중심/줌 계산으로 초기 지도 뷰가 여행 경로에 맞게 설정됩니다.
  * 단일 지점 및 시작-끝 지점 처리로 짧은 경로도 정확히 표시됩니다.
  * 라이트 모드 활성화로 렌더링 성능이 개선됩니다.
  * 지도 로고가 화면 좌하단에 고정 배치됩니다.

* 스타일
  * 경로 외곽선 제거로 경로 가시성이 향상됩니다.
  * 초기 줌 및 최소/최대 줌 범위를 미세 조정해 일관된 보기 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->