### PR TITLE
[FEAT] 홈 화면에서 신고하기 버튼 터치시 경고창을 띄우도록 기능 구현

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,6 +33,7 @@
     "expo-apple-authentication": "~7.2.4",
     "expo-blur": "~14.1.4",
     "expo-build-properties": "~0.14.8",
+    "expo-checkbox": "~4.1.4",
     "expo-clipboard": "~7.1.4",
     "expo-constants": "~17.1.6",
     "expo-dev-client": "~5.2.4",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,7 @@
     "@expo/cli": "0.24.20",
     "@expo/vector-icons": "^14.1.0",
     "@mj-studio/react-native-naver-map": "^2.6.1",
+    "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-voice/voice": "^3.2.4",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",

--- a/packages/app/src/app/(tabs)/home/index.tsx
+++ b/packages/app/src/app/(tabs)/home/index.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/native";
 import { ImageBackground } from "react-native";
 import HomeNavGridSection from "@screens/Home/HomeNavGridSection";
-// import ScreenContainer from "@shared/layout/Screen";
 import Spacing from "@shared/layout/Spacing";
 import { router } from "expo-router";
 import { useEffect } from "react";
@@ -18,6 +17,7 @@ const HomeScreen = () => {
     </Container>
   );
 };
+
 const Container = styled(ImageBackground)`
   flex: 1;
   display: flex;

--- a/packages/app/src/components/common/shared/layout/Spacing/index.tsx
+++ b/packages/app/src/components/common/shared/layout/Spacing/index.tsx
@@ -3,10 +3,15 @@ import { memo } from "react";
 
 interface SpacingProps {
   size?: number;
+  horizontal?: boolean;
 }
 
 const Spacing = memo(styled.View<SpacingProps>`
   margin-top: ${({ size }) => (size ? `${size}px` : "0")};
+  margin-left: ${({ horizontal, size }) =>
+    horizontal && size ? `${size}px` : "0"};
+  margin-right: ${({ horizontal, size }) =>
+    horizontal && size ? `${size}px` : "0"};
 `);
 
 export default Spacing;

--- a/packages/app/src/components/common/shared/ui/buttons/DefaultButton/index.tsx
+++ b/packages/app/src/components/common/shared/ui/buttons/DefaultButton/index.tsx
@@ -31,7 +31,6 @@ const DefaultButton = ({
   startIcon,
   paddingVertical,
   paddingHorizontal,
-
   onPress,
 }: DefaultButtonProps) => {
   return (

--- a/packages/app/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
@@ -9,22 +9,23 @@ import { useCallback } from "react";
 import { View } from "react-native";
 
 const HomeNavGridSection = () => {
-  const { isReportAlertVisible } = useSetModalAlertStore();
+  const { isReportAlertVisible, hydrated } = useSetModalAlertStore();
   const { showReportAlert } = useReportAlertModal();
 
   const goCourse = useCallback(() => {
     router.push("/(tabs)/home/course");
   }, []);
+
   const goTravel = useCallback(() => {
     router.push("/travel/withoutCourse");
   }, []);
+
   const goReport = useCallback(() => {
-    if (isReportAlertVisible) {
-      showReportAlert();
-    } else {
-      router.push("/report");
-    }
+    if (!hydrated) return;
+    if (isReportAlertVisible) return showReportAlert();
+    router.push("/report");
   }, [isReportAlertVisible, showReportAlert]);
+
   const goManual = useCallback(() => {
     router.push("/(tabs)/home/safeManual");
   }, []);

--- a/packages/app/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
@@ -19,9 +19,12 @@ const HomeNavGridSection = () => {
     router.push("/travel/withoutCourse");
   }, []);
   const goReport = useCallback(() => {
-    if (!isReportAlertVisible) return router.push("/report");
-    showReportAlert();
-  }, [isReportAlertVisible]);
+    if (isReportAlertVisible) {
+      showReportAlert();
+    } else {
+      router.push("/report");
+    }
+  }, [isReportAlertVisible, showReportAlert]);
   const goManual = useCallback(() => {
     router.push("/(tabs)/home/safeManual");
   }, []);

--- a/packages/app/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeNavGridSection/index.tsx
@@ -1,12 +1,17 @@
-import { COLORS } from "@styles/colorPalette";
-import Spacing from "@components/common/shared/layout/Spacing";
-import Text from "@components/common/shared/ui/Text";
 import styled from "@emotion/native";
+import useReportAlertModal from "@hooks/feature/modal/useReportAlertModal";
+import Spacing from "@shared/layout/Spacing";
+import Text from "@shared/ui/Text";
+import useSetModalAlertStore from "@store/asyncStorage/useSetModalAlertStore";
+import { COLORS } from "@styles/colorPalette";
 import { router } from "expo-router";
 import { useCallback } from "react";
 import { View } from "react-native";
 
 const HomeNavGridSection = () => {
+  const { isReportAlertVisible } = useSetModalAlertStore();
+  const { showReportAlert } = useReportAlertModal();
+
   const goCourse = useCallback(() => {
     router.push("/(tabs)/home/course");
   }, []);
@@ -14,8 +19,9 @@ const HomeNavGridSection = () => {
     router.push("/travel/withoutCourse");
   }, []);
   const goReport = useCallback(() => {
-    router.push("/report");
-  }, []);
+    if (!isReportAlertVisible) return router.push("/report");
+    showReportAlert();
+  }, [isReportAlertVisible]);
   const goManual = useCallback(() => {
     router.push("/(tabs)/home/safeManual");
   }, []);

--- a/packages/app/src/hooks/feature/modal/useReportAlertModal/index.tsx
+++ b/packages/app/src/hooks/feature/modal/useReportAlertModal/index.tsx
@@ -3,12 +3,12 @@ import useModal from "@service/modal/hooks";
 import Spacing from "@shared/layout/Spacing";
 import DefaultButton from "@shared/ui/buttons/DefaultButton";
 import Text from "@shared/ui/Text";
+import useSetModalAlertStore from "@store/asyncStorage/useSetModalAlertStore";
 import { COLORS } from "@styles/colorPalette";
+import { Checkbox } from "expo-checkbox";
 import { router } from "expo-router";
 import { useCallback, useState } from "react";
 import { View } from "react-native";
-import { Checkbox } from "expo-checkbox";
-import useSetModalAlertStore from "@store/asyncStorage/useSetModalAlertStore";
 
 const useReportAlertModal = () => {
   const { openModal, closeModal } = useModal();
@@ -31,30 +31,32 @@ const ModalComponent = ({ closeModal }: { closeModal: () => void }) => {
   const onConfirm = useCallback(() => {
     router.push("/report");
     closeModal();
-    setShowReportAlert(!isChecked);
-  }, [closeModal]);
+    if (isChecked) {
+      setShowReportAlert(false);
+    }
+  }, [closeModal, isChecked, setShowReportAlert]);
 
   return (
     <OutsideContainer activeOpacity={1} onPress={closeModal}>
       <ModalContainer>
-        <Text fontSize={14} fontWeight="medium">
+        <Text fontSize={16} fontWeight="medium">
           다음 화면에서 문자를 통해
         </Text>
-        <Text fontSize={14} fontWeight="medium">
+        <Text fontSize={16} fontWeight="medium">
           산학 구조대에 신고할 수 있습니다.
         </Text>
         <Spacing size={20} />
-        <Text fontSize={15} fontWeight="medium">
+        <Text fontSize={16} fontWeight="medium">
           허위 신고 시,
         </Text>
-        <Text fontSize={15} fontWeight="medium">
+        <Text fontSize={16} fontWeight="medium">
           소방 기본법 제56조에 따라
         </Text>
         <View style={{ flexDirection: "row", alignItems: "center" }}>
-          <Text fontSize={15} fontWeight="bold">
+          <Text fontSize={16} fontWeight="bold">
             최대 200만 원
           </Text>
-          <Text fontSize={15} fontWeight="medium">
+          <Text fontSize={16} fontWeight="medium">
             의 과태료가 부과됩니다.
           </Text>
         </View>

--- a/packages/app/src/hooks/feature/modal/useReportAlertModal/index.tsx
+++ b/packages/app/src/hooks/feature/modal/useReportAlertModal/index.tsx
@@ -1,0 +1,133 @@
+import styled from "@emotion/native";
+import useModal from "@service/modal/hooks";
+import Spacing from "@shared/layout/Spacing";
+import DefaultButton from "@shared/ui/buttons/DefaultButton";
+import Text from "@shared/ui/Text";
+import { COLORS } from "@styles/colorPalette";
+import { router } from "expo-router";
+import { useCallback, useState } from "react";
+import { View } from "react-native";
+import { Checkbox } from "expo-checkbox";
+import useSetModalAlertStore from "@store/asyncStorage/useSetModalAlertStore";
+
+const useReportAlertModal = () => {
+  const { openModal, closeModal } = useModal();
+
+  const showReportAlert = () => {
+    openModal(<ModalComponent closeModal={closeModal} />, {
+      transparent: true,
+      animationType: "none",
+      hardwareAccelerated: true,
+    });
+  };
+
+  return { showReportAlert };
+};
+
+const ModalComponent = ({ closeModal }: { closeModal: () => void }) => {
+  const [isChecked, setChecked] = useState(false);
+  const { setIsShowReportAlert: setShowReportAlert } = useSetModalAlertStore();
+
+  const onConfirm = useCallback(() => {
+    router.push("/report");
+    closeModal();
+    setShowReportAlert(!isChecked);
+  }, [closeModal]);
+
+  return (
+    <OutsideContainer activeOpacity={1} onPress={closeModal}>
+      <ModalContainer>
+        <Text fontSize={14} fontWeight="medium">
+          다음 화면에서 문자를 통해
+        </Text>
+        <Text fontSize={14} fontWeight="medium">
+          산학 구조대에 신고할 수 있습니다.
+        </Text>
+        <Spacing size={20} />
+        <Text fontSize={15} fontWeight="medium">
+          허위 신고 시,
+        </Text>
+        <Text fontSize={15} fontWeight="medium">
+          소방 기본법 제56조에 따라
+        </Text>
+        <View style={{ flexDirection: "row", alignItems: "center" }}>
+          <Text fontSize={15} fontWeight="bold">
+            최대 200만 원
+          </Text>
+          <Text fontSize={15} fontWeight="medium">
+            의 과태료가 부과됩니다.
+          </Text>
+        </View>
+
+        <Spacing size={20} />
+        <ButtonContainer>
+          <ButtonItem>
+            <DefaultButton
+              title="취소"
+              onPress={closeModal}
+              backgroundColor="gray700"
+              color="mainWhite"
+            />
+          </ButtonItem>
+          <Spacing size={4} horizontal />
+          <ButtonItem>
+            <DefaultButton title="확인" onPress={onConfirm} />
+          </ButtonItem>
+        </ButtonContainer>
+      </ModalContainer>
+      <Spacing size={16} />
+
+      <DismissibleArea onPress={() => setChecked(!isChecked)}>
+        <CheckBox value={isChecked} disabled />
+        <Text color="mainWhite">앞으로 보지 않기</Text>
+      </DismissibleArea>
+    </OutsideContainer>
+  );
+};
+
+const OutsideContainer = styled.TouchableOpacity`
+  flex: 1;
+  background-color: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContainer = styled.View`
+  display: flex;
+  text-align: center;
+  width: 300px;
+  padding: 30px;
+  background-color: ${COLORS.mainWhite};
+  border-radius: 12px;
+  align-items: center;
+  gap: 6px;
+`;
+
+const ButtonContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  width: 100%;
+  justify-content: flex-end;
+  align-items: center;
+`;
+
+const ButtonItem = styled.View`
+  flex-grow: 1;
+  padding-inline: auto;
+`;
+
+const DismissibleArea = styled.TouchableOpacity`
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+`;
+
+const CheckBox = styled(Checkbox)`
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+`;
+
+export default useReportAlertModal;

--- a/packages/app/src/service/modal/context/index.tsx
+++ b/packages/app/src/service/modal/context/index.tsx
@@ -1,10 +1,12 @@
 import { createContext, ReactNode } from "react";
 
+import type { Options } from "../models";
+
 export interface ModalContextType {
   modalState: {
     visible: boolean;
   };
-  openModal: (component: ReactNode) => void;
+  openModal: (component: ReactNode, options?: Options) => void;
   closeModal: () => void;
 }
 

--- a/packages/app/src/service/modal/context/index.tsx
+++ b/packages/app/src/service/modal/context/index.tsx
@@ -5,6 +5,7 @@ import type { Options } from "../models";
 export interface ModalContextType {
   modalState: {
     visible: boolean;
+    modalProps?: Options;
   };
   openModal: (component: ReactNode, options?: Options) => void;
   closeModal: () => void;

--- a/packages/app/src/service/modal/models/index.ts
+++ b/packages/app/src/service/modal/models/index.ts
@@ -1,1 +1,4 @@
+import { ModalProps } from "react-native";
+
 export type ModalAnimationType = "slide" | "none" | "fade" | undefined;
+export type Options = Omit<ModalProps, "visible" | "onRequestClose">;

--- a/packages/app/src/service/modal/provider/index.tsx
+++ b/packages/app/src/service/modal/provider/index.tsx
@@ -16,11 +16,14 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
   const [modalProps, setModalProps] = useState<Options>({});
 
   // Callback Functions
-  const openModal = useCallback((component: ReactNode, options?: Options) => {
-    setModalComponent(component);
-    setModalProps(options);
-    setVisible(true);
-  }, []);
+  const openModal = useCallback(
+    (component: ReactNode, options: Options = {}) => {
+      setModalComponent(component);
+      setModalProps(options);
+      setVisible(true);
+    },
+    [],
+  );
 
   const closeModal = useCallback(() => {
     setVisible(false);
@@ -36,7 +39,7 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
       openModal,
       closeModal,
     }),
-    [visible, openModal, closeModal],
+    [visible, modalProps, openModal, closeModal],
   );
 
   return (

--- a/packages/app/src/service/modal/provider/index.tsx
+++ b/packages/app/src/service/modal/provider/index.tsx
@@ -7,15 +7,18 @@ import {
 } from "react";
 import { Modal } from "react-native";
 import ModalContext, { ModalContextType } from "../context";
+import type { Options } from "../models";
 
 const ModalProvider = ({ children }: PropsWithChildren) => {
   // Context State
   const [visible, setVisible] = useState(false);
   const [modalComponent, setModalComponent] = useState<ReactNode>(null);
+  const [modalProps, setModalProps] = useState<Options>({});
 
   // Callback Functions
-  const openModal = useCallback((component: ReactNode) => {
+  const openModal = useCallback((component: ReactNode, options?: Options) => {
     setModalComponent(component);
+    setModalProps(options);
     setVisible(true);
   }, []);
 
@@ -28,6 +31,7 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
     () => ({
       modalState: {
         visible,
+        modalProps,
       },
       openModal,
       closeModal,
@@ -40,9 +44,10 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
       {children && children}
       <Modal
         animationType="fade"
-        transparent={false}
+        transparent={true}
         visible={visible}
         onRequestClose={closeModal}
+        {...modalProps}
       >
         {modalComponent && modalComponent}
       </Modal>

--- a/packages/app/src/store/asyncStorage/useSetModalAlertStore/index.ts
+++ b/packages/app/src/store/asyncStorage/useSetModalAlertStore/index.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface SetModalAlertStore {
+  isReportAlertVisible: boolean;
+  setIsShowReportAlert: (show: boolean) => void;
+}
+
+export const REPORT_ALERT_KEY = "reportAlertShow";
+
+const useSetModalAlertStore = create<SetModalAlertStore>()(
+  persist(
+    (set) => ({
+      isReportAlertVisible: true,
+      setIsShowReportAlert: (show: boolean) =>
+        set(() => ({ isReportAlertVisible: show })),
+    }),
+    {
+      name: REPORT_ALERT_KEY,
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: ({ isReportAlertVisible }) => ({ isReportAlertVisible }),
+    },
+  ),
+);
+
+export default useSetModalAlertStore;

--- a/packages/app/src/store/asyncStorage/useSetModalAlertStore/index.ts
+++ b/packages/app/src/store/asyncStorage/useSetModalAlertStore/index.ts
@@ -5,6 +5,8 @@ import { createJSONStorage, persist } from "zustand/middleware";
 interface SetModalAlertStore {
   isReportAlertVisible: boolean;
   setIsShowReportAlert: (show: boolean) => void;
+  hydrated: boolean;
+  setHydrated: (hydrated: boolean) => void;
 }
 
 export const REPORT_ALERT_KEY = "reportAlertShow";
@@ -15,11 +17,16 @@ const useSetModalAlertStore = create<SetModalAlertStore>()(
       isReportAlertVisible: true,
       setIsShowReportAlert: (show: boolean) =>
         set(() => ({ isReportAlertVisible: show })),
+      hydrated: false,
+      setHydrated: (hydrated: boolean) => set({ hydrated }),
     }),
     {
       name: REPORT_ALERT_KEY,
       storage: createJSONStorage(() => AsyncStorage),
       partialize: ({ isReportAlertVisible }) => ({ isReportAlertVisible }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHydrated(true);
+      },
     },
   ),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,6 +3068,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-async-storage/async-storage@npm:2.1.2":
+  version: 2.1.2
+  resolution: "@react-native-async-storage/async-storage@npm:2.1.2"
+  dependencies:
+    merge-options: "npm:^3.0.4"
+  peerDependencies:
+    react-native: ^0.0.0-0 || >=0.65 <1.0
+  checksum: 10c0/8f3d6ff1b32ef8705c5c8be8248988cfbfd571c0e8142b8aef15429f13ddc9a018792b4be837215f6592c76b9cd99a931d4f0ab4182eebd8bddede458d484053
+  languageName: node
+  linkType: hard
+
 "@react-native-voice/voice@npm:^3.2.4":
   version: 3.2.4
   resolution: "@react-native-voice/voice@npm:3.2.4"
@@ -4835,6 +4846,7 @@ __metadata:
     "@expo/cli": "npm:0.24.20"
     "@expo/vector-icons": "npm:^14.1.0"
     "@mj-studio/react-native-naver-map": "npm:^2.6.1"
+    "@react-native-async-storage/async-storage": "npm:2.1.2"
     "@react-native-voice/voice": "npm:^3.2.4"
     "@react-navigation/bottom-tabs": "npm:^7.2.0"
     "@react-navigation/native": "npm:^7.0.14"
@@ -9112,6 +9124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: 10c0/e5c9814cdaa627a9ad0a0964ded0e0491bfd9ace405c49a5d63c88b30a162f1512c069d5b80997893c4d0181eadc3fed02b4ab4b81059aba5620bfcdfdeb9c53
+  languageName: node
+  linkType: hard
+
 "is-potential-custom-element-name@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
@@ -10562,6 +10581,15 @@ __metadata:
   version: 6.0.0
   resolution: "memoize-one@npm:6.0.0"
   checksum: 10c0/45c88e064fd715166619af72e8cf8a7a17224d6edf61f7a8633d740ed8c8c0558a4373876c9b8ffc5518c2b65a960266adf403cc215cb1e90f7e262b58991f54
+  languageName: node
+  linkType: hard
+
+"merge-options@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "merge-options@npm:3.0.4"
+  dependencies:
+    is-plain-obj: "npm:^2.1.0"
+  checksum: 10c0/02b5891ceef09b0b497b5a0154c37a71784e68ed71b14748f6fd4258ffd3fe4ecd5cb0fd6f7cae3954fd11e7686c5cb64486daffa63c2793bbe8b614b61c7055
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4858,6 +4858,7 @@ __metadata:
     expo-apple-authentication: "npm:~7.2.4"
     expo-blur: "npm:~14.1.4"
     expo-build-properties: "npm:~0.14.8"
+    expo-checkbox: "npm:~4.1.4"
     expo-clipboard: "npm:~7.1.4"
     expo-constants: "npm:~17.1.6"
     expo-dev-client: "npm:~5.2.4"
@@ -7492,6 +7493,20 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 10c0/7c41bd282f0a35ce73da82d5a4bfcfe88ce3a1bf34737bcd06c9f2d4f7100bbf31653ff0171d92c18a13f5322f831b224f9e47bf5b05df8f15d9514d53d0c51b
+  languageName: node
+  linkType: hard
+
+"expo-checkbox@npm:~4.1.4":
+  version: 4.1.4
+  resolution: "expo-checkbox@npm:4.1.4"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-web: "*"
+  peerDependenciesMeta:
+    react-native-web:
+      optional: true
+  checksum: 10c0/cb7a04404c175a685ef6ff5c8e62ef4b9210f3f2479033a2d61a5cd3c940598ee5baec0a639f4c6839fc2f1382e3f0bd7b9fd5636c276b444c39678407db9a46
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- #17

홈 화면에서 신고하기 버튼 터치시 경고창을 띄우도록 구현하였습니다. 

<div align="center">
<video width="25%" src="https://github.com/user-attachments/assets/06f531fc-02f1-44e0-82b2-c507850e6733"/>
</div>

모달의 경우 이전에 만들어 두었던 modal service 라이브러리를 사용하였습니다. 
사용자는 모달 하단에 있는 `앞으로 보지 않기`를 선택한 경우, 이 상태의 값을 async storage에 저장하도록 하였습니다.
이후 앱에서는 aysnc storage에 접근하여 사용자가 이전에 `앞으로 보지 않기`를 선택을 했었다면 모달을 보여주지 않고 바로 신고 페이지로 이동하도록 구현하였습니다. 

스토리지의 접근하는 방식에 대하여, 무조건적으로 로컬 상태 라이브러리(zustand)를 거치도록 하였습니다. 
이는 아래의 장점을 기대할 수 있을 것이라 생각하였습니다. 
- 반응성 : 스토리지에 접근하는 경우, 비동기적으로 동작할 수 있으며, 이는 컴포넌트의 반응성에 대한 이슈가 발생할 수 있습니다. 반면 이를 상태로서 관리하게 된다면 컴포넌트에 변경된 데이터에 대한 리랜더링을 통하여 빠른 반응성을 기대할 수 있습니다. 
- 리액트적으로 작성 가능 : 스토리지의 접근은 대부분 사이드 이팩트로서 관리가 됩니다. 이는 가독성을 해칠 수 있는 문제점이 존재합니다. 반면 이를 상태로서 관리하게 되면 리액트적으로 코드를 사용할 수 있게 됩니다. 
- 타 컴포넌트에서 데이터 변경 감지 가능 : 스토리지는 데이터를 변경하여도 재접근 하지 않는 이상 변경됨을 감지할 수 없습니다. 이로 인하여 과거의 데이터를 바탕으로 동작하는 문제가 발생할 수 있습니다. 반면 이를 상태로 관리하면 변경을 감지하고 새롭게 ui를 그릴 수 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 보고하기 선택 시 경고 모달이 표시되고 “앞으로 보지 않기” 선택으로 이후 미표시를 저장·적용할 수 있습니다.
  - 모달 표시 방식이 확장되어 투명 배경 등 추가 옵션을 지원합니다.
  - 일부 레이아웃 컴포넌트가 가로 간격을 지원하도록 업데이트되어 UI 배치 유연성이 향상되었습니다.

- **작업**
  - 앱에 기기 저장소(AsyncStorage) 및 체크박스 UI 라이브러리가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->