### PR TITLE
[FEAT] 알림 설정 페이지 구현

### DIFF
--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -56,6 +56,14 @@
         {
           "type": "route",
           "uuid": "e69b27d3-d2ef-4dc5-8537-5285368eb950"
+        },
+        {
+          "type": "route",
+          "uuid": "594fa34e-0b9c-48e0-a720-248b5e4c8dbd"
+        },
+        {
+          "type": "route",
+          "uuid": "db9a64bc-8fc3-4861-b4e6-bd02afe62e99"
         }
       ]
     },
@@ -786,6 +794,64 @@
         {
           "uuid": "09ead24d-543b-4e53-8eeb-36828d6a560e",
           "body": "{\n  \"data\": { \n    \"recordId\": 12,\n    \"displayName\": \"새인봉 - 서석대\",\n    \"startedAt\": 1759152556,\n    \"endAt\": 1759152556,\n    \"duration\": 210,\n    \"length\": 6.2,\n    \"coordinates\": [\n      [127.12345678901234, 37.12345678901234],\n      [127.12345978901233, 37.12345678901234]\n    ],\n    \"courseId\": 6,\n    \"mountainId\": 1\n  },\n  \"status\": \"success\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "594fa34e-0b9c-48e0-a720-248b5e4c8dbd",
+      "type": "http",
+      "documentation": "사용자 알림 설정값 조회",
+      "method": "get",
+      "endpoint": "api/v1/users/alert",
+      "responses": [
+        {
+          "uuid": "1acdca19-2253-4606-bf69-e3d669febbb4",
+          "body": "{\n  \"data\": {\n    \"userAlertSetting\": {\n      \"eventAlert\": true,\n      \"travelDeviationAlert\": true,\n      \"accidentProneAreaAlert\": true\n    }\n  },\n  \"status\": \"success\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "db9a64bc-8fc3-4861-b4e6-bd02afe62e99",
+      "type": "http",
+      "documentation": "사용자 알림 설정값 등록",
+      "method": "put",
+      "endpoint": "api/v1/users/alert",
+      "responses": [
+        {
+          "uuid": "bcdf68b1-58c4-4856-a1c8-c78615e90bef",
+          "body": "{\n  \t\"data\" : null\n\t\t\"status\" : \"sucess\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",

--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -822,7 +822,7 @@
       "responses": [
         {
           "uuid": "1acdca19-2253-4606-bf69-e3d669febbb4",
-          "body": "{\n  \"data\": {\n    \"userAlertSetting\": {\n      \"eventAlert\": true,\n      \"travelDeviationAlert\": true,\n      \"accidentProneAreaAlert\": true\n    }\n  },\n  \"status\": \"success\"\n}",
+          "body": "{\n  \"data\": {\n    \"userAlertSetting\": {\n      \"eventAlert\": true,\n      \"travelRecordCountAlert\": true,\n      \"travelDeviationAlert\": true,\n      \"accidentProneAreaAlert\": true\n    }\n  },\n  \"status\": \"success\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",
@@ -851,7 +851,7 @@
       "responses": [
         {
           "uuid": "bcdf68b1-58c4-4856-a1c8-c78615e90bef",
-          "body": "{\n  \t\"data\" : null\n\t\t\"status\" : \"sucess\"\n}",
+          "body": "{\n  \t\"data\" : null,\n\t\t\"status\" : \"success\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",

--- a/packages/api/src/api/v1/bases/index.ts
+++ b/packages/api/src/api/v1/bases/index.ts
@@ -36,10 +36,10 @@ export interface GetBasesApiResponse {
  * console.log(result.bases); // BaseMarker[]
  */
 export const getBasesApi = async (
-  Instance: AxiosInstance,
+  instance: AxiosInstance,
   mountainId: string,
 ) => {
-  const response = await Instance<GetBasesApiResponse>({
+  const response = await instance<GetBasesApiResponse>({
     method: "get",
     url: BASES_API_PATH(mountainId),
   });

--- a/packages/api/src/api/v1/bases/index.ts
+++ b/packages/api/src/api/v1/bases/index.ts
@@ -28,7 +28,7 @@ export interface GetBasesApiResponse {
  * @public
  * @category Bases
  * @description 특정 산의 베이스 목록을 조회합니다
- * @param Instance - Axios 인스턴스
+ * @param instance - Axios 인스턴스
  * @param mountainId - 산 ID
  * @returns 베이스 목록 정보
  * @example

--- a/packages/api/src/api/v1/bookmarks/index.ts
+++ b/packages/api/src/api/v1/bookmarks/index.ts
@@ -11,6 +11,7 @@ export const BOOKMARK_API_PATH = "/api/v1/bookmarks";
 /**
  * @public
  * @category Types
+ * @interface Bookmark
  * @description 북마크 정보 타입
  * @property {string} id - 코스 ID
  * @property {string} name - 코스 이름

--- a/packages/api/src/api/v1/travel/records/[recordId]/details/index.ts
+++ b/packages/api/src/api/v1/travel/records/[recordId]/details/index.ts
@@ -19,7 +19,15 @@ export const TRAVEL_RECORD_DETAILS_API_PATH = ({
  * @category Types
  * @interface GetTravelRecordDetailsResponse
  * @description 산행 기록 상세 조회 응답 타입
- * @property {Record[]} records - 산행 기록 상세 목록
+ * @property {string} recordId - 기록 ID
+ * @property {string} displayName - 코스 표시 이름
+ * @property {number} startedAt - 시작 시간 (timestamp)
+ * @property {number} endAt - 종료 시간 (timestamp)
+ * @property {number} duration - 소요 시간 (초)
+ * @property {number} length - 거리 (m)
+ * @property {[number, number][]} coordinates - GPS 좌표 배열 ([위도, 경도])
+ * @property {string} courseId - 코스 ID
+ * @property {string} mountainId - 산 ID
  */
 export interface GetTravelRecordDetailsResponse {
   recordId: string;

--- a/packages/api/src/api/v1/users/alert/index.ts
+++ b/packages/api/src/api/v1/users/alert/index.ts
@@ -18,13 +18,13 @@ export const USER_ALERT_API_PATH = "/api/v1/users/alert";
  * @property {boolean} accidentProneAreaAlert - 사고 다발 지역 알림
  */
 export interface GetAlertResponse {
-  eventAlert: boolean;
-  travelRecordCountAlert: boolean;
-  travelDeviationAlert: boolean;
-  accidentProneAreaAlert: boolean;
+  userAlertSetting: {
+    eventAlert: boolean;
+    travelRecordCountAlert: boolean;
+    travelDeviationAlert: boolean;
+    accidentProneAreaAlert: boolean;
+  };
 }
-
-// TODO: api 변경 반영 필요
 
 /**
  * @public
@@ -37,13 +37,28 @@ export interface GetAlertResponse {
  * console.log(result.eventAlert); // true/false
  */
 export const getAlert = async (instance: AxiosInstance) => {
-  const response = await instance({
+  const response = await instance<GetAlertResponse>({
     method: "GET",
     url: USER_ALERT_API_PATH,
   });
 
   return response.data;
 };
+
+/**
+ * @public
+ * @category Types
+ * @interface PutAlertRequest
+ * @description 알림 설정 수정 요청 타입
+ * @property {boolean} eventAlert - 이벤트 알림
+ * @property {boolean} travelDeviationAlert - 등산로 이탈 알림
+ * @property {boolean} accidentProneAreaAlert - 사고 다발 지역 알림
+ */
+export interface PutAlertRequest {
+  eventAlert: boolean;
+  travelDeviationAlert: boolean;
+  accidentProneAreaAlert: boolean;
+}
 
 /**
  * @public
@@ -62,7 +77,7 @@ export const getAlert = async (instance: AxiosInstance) => {
  */
 export const putAlert = async (
   instance: AxiosInstance,
-  body: GetAlertResponse,
+  body: PutAlertRequest,
 ) => {
   const response = await instance({
     method: "PUT",

--- a/packages/app/src/app/(tabs)/mypage/notificationSetting.tsx
+++ b/packages/app/src/app/(tabs)/mypage/notificationSetting.tsx
@@ -1,10 +1,12 @@
-import MypageNotificationSettingWebview from "@screens/mypage/MypageNotificationSettingWebview";
+import NotificationHeader from "@screens/notification/NotificationHeader";
+import NotificationList from "@screens/notification/NotificationList";
 import ScreenContainer from "@shared/layout/Screen";
 
 const NotificationSettingScreen = () => {
   return (
     <ScreenContainer>
-      <MypageNotificationSettingWebview />
+      <NotificationHeader />
+      <NotificationList />
     </ScreenContainer>
   );
 };

--- a/packages/app/src/components/common/entities/SwitchItem/index.tsx
+++ b/packages/app/src/components/common/entities/SwitchItem/index.tsx
@@ -1,0 +1,47 @@
+import styled from "@emotion/native";
+import Text from "@shared/ui/Text";
+import { COLORS } from "@styles/colorPalette";
+import { Switch } from "react-native";
+
+interface SwitchItemProps {
+  text: string;
+  value?: boolean;
+  onToggle?: (value: boolean) => void;
+
+  // style
+  borderBottom?: boolean;
+}
+
+const SwitchItem = ({
+  text,
+  value,
+  onToggle,
+  borderBottom,
+}: SwitchItemProps) => {
+  return (
+    <NotificationItem borderBottom={borderBottom}>
+      <Text fontSize={16} fontWeight="medium">
+        {text}
+      </Text>
+
+      <Switch
+        value={value}
+        onValueChange={() => {
+          onToggle?.(!value);
+        }}
+      />
+    </NotificationItem>
+  );
+};
+
+const NotificationItem = styled.View<{ borderBottom?: boolean }>`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  border-bottom-width: ${({ borderBottom }) => (borderBottom ? "1px" : "0px")};
+  border-bottom-color: ${COLORS.gray400};
+  border-bottom-style: solid;
+  padding-bottom: 12px;
+`;
+
+export default SwitchItem;

--- a/packages/app/src/components/common/entities/WeakHeader/index.tsx
+++ b/packages/app/src/components/common/entities/WeakHeader/index.tsx
@@ -1,0 +1,36 @@
+import styled from "@emotion/native";
+import BackButton from "@components/common/entities/BackButton";
+import Text from "@shared/ui/Text";
+import { COLORS } from "@styles/colorPalette";
+
+interface WeakHeaderProps {
+  headerText?: string;
+}
+
+export default function WeakHeader({ headerText }: WeakHeaderProps) {
+  return (
+    <HeaderContainer>
+      <BackButtonWrapper>
+        <BackButton />
+      </BackButtonWrapper>
+      <Text fontSize={16} fontWeight="medium" textAlign="center">
+        {headerText}
+      </Text>
+    </HeaderContainer>
+  );
+}
+
+const HeaderContainer = styled.View`
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding-top: 16px;
+  padding-bottom: 12px;
+  background-color: ${COLORS.mainWhite};
+  position: relative;
+`;
+
+const BackButtonWrapper = styled.View`
+  position: absolute;
+  left: 16px;
+`;

--- a/packages/app/src/components/feature/screens/mypage/MypageNotificationSettingWebview/index.tsx
+++ b/packages/app/src/components/feature/screens/mypage/MypageNotificationSettingWebview/index.tsx
@@ -1,6 +1,7 @@
 import PATH_ROUTE from "@constants/pathRoute";
 import WebViewWithInjected from "@entities/WebViewWithInjected";
 
+// [!warning] 더 이상 사용하지 않습니다! 해당 페이지는 앱에서 구현합니다
 const MypageNotificationSettingWebview = () => {
   return (
     <WebViewWithInjected source={{ uri: PATH_ROUTE.WEBVIEW.TRAVEL_LOG }} />

--- a/packages/app/src/components/feature/screens/notification/NotificationHeader/index.tsx
+++ b/packages/app/src/components/feature/screens/notification/NotificationHeader/index.tsx
@@ -1,0 +1,7 @@
+import WeakHeader from "@entities/WeakHeader";
+
+const NotificationHeader = () => {
+  return <WeakHeader headerText="알림 설정" />;
+};
+
+export default NotificationHeader;

--- a/packages/app/src/components/feature/screens/notification/NotificationList/index.tsx
+++ b/packages/app/src/components/feature/screens/notification/NotificationList/index.tsx
@@ -1,0 +1,189 @@
+import styled from "@emotion/native";
+import SwitchItem from "@entities/SwitchItem";
+import useNotificationModal from "@hooks/feature/modal/useNotificationModal";
+import useNotificationMutation from "@hooks/feature/query/mutate/useNotificationMutation";
+import useNotificationQuery from "@hooks/feature/query/query/useNotificationQuery";
+import Spacing from "@shared/layout/Spacing";
+import { Suspense } from "@suspensive/react";
+import { useState } from "react";
+
+import NotificationListLoader from "./loader";
+
+const NotificationList = Suspense.with(
+  {
+    fallback: <NotificationListLoader />,
+  },
+  () => {
+    const {
+      data: {
+        userAlertSetting: {
+          eventAlert,
+          accidentProneAreaAlert,
+          travelDeviationAlert,
+        },
+      },
+    } = useNotificationQuery();
+    const { mutate: updateAlertSetting } = useNotificationMutation();
+    const { showNotificationModal } = useNotificationModal();
+
+    const [notificationSetting, setNotificationSetting] = useState({
+      eventAlert,
+      accidentProneAreaAlert,
+      travelDeviationAlert,
+    });
+
+    const handleEventToggle = (value: boolean) => {
+      setNotificationSetting((prev) => ({ ...prev, eventAlert: value }));
+      updateAlertSetting({
+        eventAlert: value,
+        travelDeviationAlert: notificationSetting.travelDeviationAlert,
+        accidentProneAreaAlert: notificationSetting.accidentProneAreaAlert,
+      });
+    };
+
+    const handleRouteDeviationToggle = (value: boolean) => {
+      if (!value) {
+        showNotificationModal({
+          onConfirm: () => {
+            setNotificationSetting((prev) => ({
+              ...prev,
+              travelDeviationAlert: value,
+            }));
+            updateAlertSetting({
+              eventAlert: notificationSetting.eventAlert,
+              travelDeviationAlert: value,
+              accidentProneAreaAlert:
+                notificationSetting.accidentProneAreaAlert,
+            });
+          },
+          onCancel: () => {
+            setNotificationSetting((prev) => ({
+              ...prev,
+              travelDeviationAlert: !value,
+            }));
+          },
+        });
+        return;
+      }
+      setNotificationSetting((prev) => ({
+        ...prev,
+        travelDeviationAlert: value,
+      }));
+      updateAlertSetting({
+        eventAlert: notificationSetting.eventAlert,
+        travelDeviationAlert: value,
+        accidentProneAreaAlert: notificationSetting.accidentProneAreaAlert,
+      });
+    };
+
+    const handleAccidentZoneToggle = (value: boolean) => {
+      if (!value) {
+        showNotificationModal({
+          onConfirm: () => {
+            setNotificationSetting((prev) => ({
+              ...prev,
+              accidentProneAreaAlert: value,
+            }));
+            updateAlertSetting({
+              eventAlert: notificationSetting.eventAlert,
+              travelDeviationAlert: notificationSetting.travelDeviationAlert,
+              accidentProneAreaAlert: value,
+            });
+          },
+          onCancel: () => {
+            setNotificationSetting((prev) => ({
+              ...prev,
+              accidentProneAreaAlert: !value,
+            }));
+          },
+        });
+        return;
+      }
+      setNotificationSetting((prev) => ({
+        ...prev,
+        accidentProneAreaAlert: value,
+      }));
+      updateAlertSetting({
+        eventAlert: notificationSetting.eventAlert,
+        travelDeviationAlert: notificationSetting.travelDeviationAlert,
+        accidentProneAreaAlert: value,
+      });
+    };
+
+    const handleAllToggle = (value: boolean) => {
+      if (!value) {
+        showNotificationModal({
+          onConfirm: () => {
+            setNotificationSetting({
+              eventAlert: value,
+              accidentProneAreaAlert: value,
+              travelDeviationAlert: value,
+            });
+            updateAlertSetting({
+              eventAlert: value,
+              travelDeviationAlert: value,
+              accidentProneAreaAlert: value,
+            });
+          },
+          onCancel: () => {
+            setNotificationSetting({
+              eventAlert: true,
+              accidentProneAreaAlert: true,
+              travelDeviationAlert: true,
+            });
+          },
+        });
+        return;
+      }
+      setNotificationSetting({
+        eventAlert: value,
+        accidentProneAreaAlert: value,
+        travelDeviationAlert: value,
+      });
+      updateAlertSetting({
+        eventAlert: value,
+        travelDeviationAlert: value,
+        accidentProneAreaAlert: value,
+      });
+    };
+
+    return (
+      <Container>
+        <SwitchItem
+          text="전체 알림"
+          borderBottom
+          value={
+            notificationSetting.eventAlert &&
+            notificationSetting.accidentProneAreaAlert &&
+            notificationSetting.travelDeviationAlert
+          }
+          onToggle={handleAllToggle}
+        />
+        <Spacing size={32} />
+        <SwitchItem
+          text="이벤트·혜택 알림"
+          value={notificationSetting.eventAlert}
+          onToggle={handleEventToggle}
+        />
+        <Spacing size={32} />
+        <SwitchItem
+          text="경로 이탈 알림"
+          value={notificationSetting.travelDeviationAlert}
+          onToggle={handleRouteDeviationToggle}
+        />
+        <Spacing size={32} />
+        <SwitchItem
+          text="사고 다발 구역 알림"
+          value={notificationSetting.accidentProneAreaAlert}
+          onToggle={handleAccidentZoneToggle}
+        />
+      </Container>
+    );
+  },
+);
+
+const Container = styled.View`
+  padding: 28px;
+`;
+
+export default NotificationList;

--- a/packages/app/src/components/feature/screens/notification/NotificationList/loader.tsx
+++ b/packages/app/src/components/feature/screens/notification/NotificationList/loader.tsx
@@ -1,0 +1,30 @@
+import styled from "@emotion/native";
+import Spacing from "@shared/layout/Spacing";
+import { COLORS } from "@styles/colorPalette";
+
+const NotificationListLoader = () => {
+  return (
+    <Container>
+      <Box />
+      <Spacing size={20} />
+      <Box />
+      <Spacing size={20} />
+      <Box />
+      <Spacing size={20} />
+      <Box />
+    </Container>
+  );
+};
+
+const Container = styled.View`
+  padding: 24px;
+`;
+
+const Box = styled.View`
+  width: 100%;
+  height: 32px;
+  background-color: ${COLORS.gray300};
+  border-radius: 8px;
+`;
+
+export default NotificationListLoader;

--- a/packages/app/src/hooks/feature/modal/useNotificationModal/index.tsx
+++ b/packages/app/src/hooks/feature/modal/useNotificationModal/index.tsx
@@ -47,14 +47,14 @@ const ModalComponent = ({
       onConfirm();
     }
     closeModal();
-  }, [closeModal]);
+  }, [closeModal, onConfirm]);
 
   const handleCancel = useCallback(() => {
     if (onCancel) {
       onCancel();
     }
     closeModal();
-  }, [closeModal]);
+  }, [closeModal, onCancel]);
 
   return (
     <OutsideContainer activeOpacity={1} onPress={closeModal}>

--- a/packages/app/src/hooks/feature/modal/useNotificationModal/index.tsx
+++ b/packages/app/src/hooks/feature/modal/useNotificationModal/index.tsx
@@ -1,0 +1,118 @@
+import styled from "@emotion/native";
+import useModal from "@service/modal/hooks";
+import Spacing from "@shared/layout/Spacing";
+import DefaultButton from "@shared/ui/buttons/DefaultButton";
+import Text from "@shared/ui/Text";
+import { COLORS } from "@styles/colorPalette";
+import { useCallback } from "react";
+
+const useNotificationModal = () => {
+  const { openModal, closeModal } = useModal();
+
+  const showNotificationModal = ({
+    onConfirm,
+    onCancel,
+  }: {
+    onConfirm?: () => void;
+    onCancel?: () => void;
+  }) => {
+    openModal(
+      <ModalComponent
+        closeModal={closeModal}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+      {
+        transparent: true,
+        animationType: "none",
+        hardwareAccelerated: true,
+      },
+    );
+  };
+
+  return { showNotificationModal };
+};
+
+const ModalComponent = ({
+  closeModal,
+  onConfirm,
+  onCancel,
+}: {
+  closeModal: () => void;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}) => {
+  const handleConfirm = useCallback(() => {
+    if (onConfirm) {
+      onConfirm();
+    }
+    closeModal();
+  }, [closeModal]);
+
+  const handleCancel = useCallback(() => {
+    if (onCancel) {
+      onCancel();
+    }
+    closeModal();
+  }, [closeModal]);
+
+  return (
+    <OutsideContainer activeOpacity={1} onPress={closeModal}>
+      <ModalContainer>
+        <Text>알림을 해제할 시</Text>
+        <Text>안전한 산행 지원이 어려워집니다.</Text>
+        <Text>해제하시겠습니까?</Text>
+        <Spacing size={20} />
+        <ButtonContainer>
+          <ButtonItem>
+            <DefaultButton
+              title="취소"
+              onPress={handleCancel}
+              backgroundColor="gray700"
+              color="mainWhite"
+            />
+          </ButtonItem>
+          <Spacing size={4} horizontal />
+          <ButtonItem>
+            <DefaultButton title="확인" onPress={handleConfirm} />
+          </ButtonItem>
+        </ButtonContainer>
+      </ModalContainer>
+    </OutsideContainer>
+  );
+};
+
+const OutsideContainer = styled.TouchableOpacity`
+  flex: 1;
+  background-color: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContainer = styled.View`
+  display: flex;
+  text-align: center;
+  width: 300px;
+  padding: 20px;
+  padding-top: 40px;
+  background-color: ${COLORS.mainWhite};
+  border-radius: 12px;
+  align-items: center;
+  gap: 6px;
+`;
+
+const ButtonContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  width: 100%;
+  justify-content: flex-end;
+  align-items: center;
+`;
+
+const ButtonItem = styled.View`
+  flex-grow: 1;
+  padding-inline: auto;
+`;
+
+export default useNotificationModal;

--- a/packages/app/src/hooks/feature/query/mutate/useNotificationMutation/index.ts
+++ b/packages/app/src/hooks/feature/query/mutate/useNotificationMutation/index.ts
@@ -7,7 +7,7 @@ const useNotificationMutation = () => {
   return useMutation({
     mutationKey: [USER_ALERT_API_PATH],
     mutationFn: (body: PutAlertRequest) => putAlert(authenticatedApi, body),
-    onMutate: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [USER_ALERT_API_PATH] });
     },
   });

--- a/packages/app/src/hooks/feature/query/mutate/useNotificationMutation/index.ts
+++ b/packages/app/src/hooks/feature/query/mutate/useNotificationMutation/index.ts
@@ -1,0 +1,16 @@
+import authenticatedApi from "@api/_instances/authenticatedApi";
+import queryClient from "@service/query/client";
+import { useMutation } from "@tanstack/react-query";
+import { putAlert, PutAlertRequest, USER_ALERT_API_PATH } from "api";
+
+const useNotificationMutation = () => {
+  return useMutation({
+    mutationKey: [USER_ALERT_API_PATH],
+    mutationFn: (body: PutAlertRequest) => putAlert(authenticatedApi, body),
+    onMutate: () => {
+      queryClient.invalidateQueries({ queryKey: [USER_ALERT_API_PATH] });
+    },
+  });
+};
+
+export default useNotificationMutation;

--- a/packages/app/src/hooks/feature/query/query/useNotificationQuery/index.ts
+++ b/packages/app/src/hooks/feature/query/query/useNotificationQuery/index.ts
@@ -1,0 +1,12 @@
+import authenticatedApi from "@api/_instances/authenticatedApi";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getAlert, USER_ALERT_API_PATH } from "api";
+
+const useNotificationQuery = () => {
+  return useSuspenseQuery({
+    queryKey: [USER_ALERT_API_PATH],
+    queryFn: () => getAlert(authenticatedApi),
+  });
+};
+
+export default useNotificationQuery;


### PR DESCRIPTION
- #20

알림 설정 페이지를 구현하였습니다. 

<div align="center">
<img width="25%" src="https://github.com/user-attachments/assets/b08e15a4-90af-413d-b36f-077280af82a6"/>
</div>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 마이페이지 알림 설정 네이티브 전면 개편: 약식 헤더, 로딩 스켈레톤, 전체/개별(이벤트·혜택, 경로 이탈, 사고다발) 토글 UI 추가
  - 토글 동작 관련 확인 모달 제공(끄기 시 확인)
  - 알림 조회/수정 실시간 연동(쿼리/뮤테이션) 및 목업 API 엔드포인트 추가

- Improvements
  - 여행 기록 상세 응답 구조 고도화로 더 풍부한 정보 표시 기반 마련

- Documentation
  - 주석·명세 표현 일관화 사항 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->