### PR TITLE
[FEAT] 위급시 개인 정보 모달 구현

### DIFF
--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -27,6 +27,10 @@
       "children": [
         {
           "type": "route",
+          "uuid": "cc30b6e7-6f72-443f-8455-6333d44ccf42"
+        },
+        {
+          "type": "route",
           "uuid": "8aeaf47c-dd06-4ce9-9cd2-eaa11048f852"
         },
         {
@@ -44,10 +48,6 @@
         {
           "type": "route",
           "uuid": "f78eb179-ecd4-457b-8ae6-957a7014a21a"
-        },
-        {
-          "type": "route",
-          "uuid": "cc30b6e7-6f72-443f-8455-6333d44ccf42"
         },
         {
           "type": "route",
@@ -648,7 +648,7 @@
       "responses": [
         {
           "uuid": "9f680107-d110-41bb-8109-7445bb1ec125",
-          "body": "{\n  \t\"data\" : {\n\t  \t  \"isComplete\" : true \n  \t},\n\t\t\"status\" : \"success\"\n}",
+          "body": "{\n  \"data\": {\n    \"userStatusInfoDTO\": {\n      \"isBasicInfoSet\": true,\n      \"isPersonalInfoSet\": false\n    }\n  },\n  \"status\": \"success\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",
@@ -822,8 +822,8 @@
       "responses": [
         {
           "uuid": "1acdca19-2253-4606-bf69-e3d669febbb4",
-          "body": "{\n  \"data\": {\n    \"userAlertSetting\": {\n      \"eventAlert\": true,\n      \"travelRecordCountAlert\": true,\n      \"travelDeviationAlert\": true,\n      \"accidentProneAreaAlert\": true\n    }\n  },\n  \"status\": \"success\"\n}",
-          "latency": 0,
+          "body": "{\n  \"data\": {\n    \"userAlertSetting\": {\n      \"eventAlert\": true,\n      \"travelDeviationAlert\": true,\n      \"accidentProneAreaAlert\": true\n    }\n  },\n  \"status\": \"success\"\n}",
+          "latency": 2000,
           "statusCode": 200,
           "label": "",
           "headers": [],
@@ -851,7 +851,7 @@
       "responses": [
         {
           "uuid": "bcdf68b1-58c4-4856-a1c8-c78615e90bef",
-          "body": "{\n  \t\"data\" : null,\n\t\t\"status\" : \"success\"\n}",
+          "body": "{\n  \t\"data\" : null\n\t\t\"status\" : \"sucess\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",

--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -880,7 +880,7 @@
       "responses": [
         {
           "uuid": "7591bf8d-997f-4474-8f28-9a7fca903949",
-          "body": "{\n\t\t\"data\" : null\n\t\t\"status\" : \"success\"\n}",
+          "body": "{\n\t\t\"data\" : null,\n\t\t\"status\" : \"success\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",

--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -870,6 +870,35 @@
         }
       ],
       "responseMode": null
+    },
+    {
+      "uuid": "a112a50e-7641-4d54-a63d-f31447773ca1",
+      "type": "http",
+      "documentation": "개인정보 등록",
+      "method": "post",
+      "endpoint": "api/v1/users/profile/personal-information",
+      "responses": [
+        {
+          "uuid": "7591bf8d-997f-4474-8f28-9a7fca903949",
+          "body": "{\n\t\t\"data\" : null\n\t\t\"status\" : \"success\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
     }
   ],
   "rootChildren": [
@@ -900,6 +929,10 @@
     {
       "type": "route",
       "uuid": "048d55f5-4513-4b7a-89ee-b84b144a4e4b"
+    },
+    {
+      "type": "route",
+      "uuid": "a112a50e-7641-4d54-a63d-f31447773ca1"
     }
   ],
   "proxyMode": false,

--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -851,7 +851,7 @@
       "responses": [
         {
           "uuid": "bcdf68b1-58c4-4856-a1c8-c78615e90bef",
-          "body": "{\n  \t\"data\" : null\n\t\t\"status\" : \"sucess\"\n}",
+          "body": "{\n  \t\"data\" : null,\n\t\t\"status\" : \"success\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",

--- a/packages/api/src/api/v1/users/profile/status/index.ts
+++ b/packages/api/src/api/v1/users/profile/status/index.ts
@@ -16,8 +16,10 @@ export const USER_PROFILE_STATUS_API_PATH = "/api/v1/users/profile/status";
  * @property {boolean} personalInformation - 개인 정보 작성 여부
  */
 export interface GetProfileStatusResponse {
-  basicInformation: boolean;
-  personalInformation: boolean;
+  userStatusInfoDTO: {
+    isBasicInfoSet: boolean;
+    isPersonalInfoSet: boolean;
+  };
 }
 
 /**

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,7 @@
     "@expo/cli": "0.24.20",
     "@expo/vector-icons": "^14.1.0",
     "@mj-studio/react-native-naver-map": "^2.6.1",
+    "@quidone/react-native-wheel-picker": "^1.6.1",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-voice/voice": "^3.2.4",
     "@react-navigation/bottom-tabs": "^7.2.0",

--- a/packages/app/src/app/(tabs)/home/index.tsx
+++ b/packages/app/src/app/(tabs)/home/index.tsx
@@ -4,11 +4,32 @@ import HomeNavGridSection from "@screens/Home/HomeNavGridSection";
 import Spacing from "@shared/layout/Spacing";
 import { router } from "expo-router";
 import { useEffect } from "react";
+import useUserProfileStatusQuery from "@hooks/feature/query/query/useUserProfileStatusQuery";
+import usePersonalInfoModal from "@hooks/feature/modal/usePersonalInfoModal";
 
 const HomeScreen = () => {
+  const {
+    data: profileStatusData,
+    // isLoading: profileStatusLoading,
+    // error: profileStatusError,
+  } = useUserProfileStatusQuery();
+  const { showNotificationModal } = usePersonalInfoModal();
+
   useEffect(() => {
     router.prefetch("/(tabs)/home/course");
   }, []);
+
+  useEffect(() => {
+    const isPersonalInfoSet =
+      profileStatusData?.userStatusInfoDTO.isPersonalInfoSet;
+    if (profileStatusData && !isPersonalInfoSet) {
+      showNotificationModal({
+        onConfirm: () => {
+          console.log("확인 클릭됨");
+        },
+      });
+    }
+  }, [profileStatusData]);
 
   return (
     <Container source={require("@assets/images/Home_Background.png")}>

--- a/packages/app/src/app/index.tsx
+++ b/packages/app/src/app/index.tsx
@@ -23,7 +23,7 @@ export default function Index() {
     isCheckingLoginLoading,
     profileStatusLoading,
     isLoggedIn,
-    isProfileComplete,
+    isBasicInfoSet,
     refreshToken,
   } = useCheckUserLoginAndProfileState();
 
@@ -66,8 +66,11 @@ export default function Index() {
 
   if (isCheckingLoginLoading || profileStatusLoading) return null; //TODO: 로딩 폴백 보여주기
 
-  if (isLoggedIn && !isProfileComplete)
+  if (isLoggedIn && !isBasicInfoSet)
     return <Redirect href="/onboarding/profile" />;
+
+  // if (isLoggedIn && !isPersonalInfoSet)
+  //   return <Redirect href="/onboarding/profile" />;
 
   // if (fontError || error) return null; //TODO: 에러 페이지로 넘기기
   if (fontError || error) return <Redirect href="/onboarding/profile" />;

--- a/packages/app/src/components/common/entities/WheelPickerTextareaField/index.tsx
+++ b/packages/app/src/components/common/entities/WheelPickerTextareaField/index.tsx
@@ -23,15 +23,18 @@ const WheelPickerTextareaField = <T extends string>({
   placeholder = "선택하세요",
 }: WheelPickerProps<T>) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [defaultValue, setDefaultValue] = useState(value);
+  const [tempValue, setTempValue] = useState(value);
 
   const handleConfirm = () => {
     setIsOpen(false);
+    if (tempValue !== null) {
+      onChange(tempValue);
+    }
   };
 
   const handleCancel = () => {
     setIsOpen(false);
-    onChange(defaultValue!);
+    setTempValue(value);
   };
 
   const getSelectedLabel = () => {
@@ -45,7 +48,7 @@ const WheelPickerTextareaField = <T extends string>({
       <InputButton
         onPress={() => {
           setIsOpen(true);
-          setDefaultValue(value);
+          setTempValue(value);
         }}
       >
         <InputText hasValue={value != null}>{getSelectedLabel()}</InputText>
@@ -74,9 +77,9 @@ const WheelPickerTextareaField = <T extends string>({
             {/* Picker Wheel */}
             <WheelPicker
               data={options}
-              value={value}
+              value={tempValue}
               onValueChanged={({ item: { value } }) => {
-                onChange(value);
+                setTempValue(value);
               }}
               enableScrollByTapOnItem={true}
             />

--- a/packages/app/src/components/common/entities/WheelPickerTextareaField/index.tsx
+++ b/packages/app/src/components/common/entities/WheelPickerTextareaField/index.tsx
@@ -1,7 +1,8 @@
+import FieldLayout from "@components/common/shared/layout/FieldLayout";
 import styled from "@emotion/native";
 import WheelPicker from "@quidone/react-native-wheel-picker";
 import { COLORS } from "@styles/colorPalette";
-import { useState } from "react";
+import { ComponentProps, useState } from "react";
 import { Modal, Platform } from "react-native";
 
 export interface WheelPickerOption<T = string> {
@@ -9,7 +10,8 @@ export interface WheelPickerOption<T = string> {
   value: T;
 }
 
-interface WheelPickerProps<T extends string> {
+interface WheelPickerProps<T extends string>
+  extends Omit<ComponentProps<typeof FieldLayout>, "content"> {
   options: WheelPickerOption<T>[];
   value: T | null;
   onChange: (value: T) => void;
@@ -21,6 +23,8 @@ const WheelPickerTextareaField = <T extends string>({
   value,
   onChange,
   placeholder = "선택하세요",
+
+  ...props
 }: WheelPickerProps<T>) => {
   const [isOpen, setIsOpen] = useState(false);
   const [tempValue, setTempValue] = useState(value);
@@ -43,50 +47,56 @@ const WheelPickerTextareaField = <T extends string>({
   };
 
   return (
-    <>
+    <FieldLayout
+      {...props}
+      content={
+        <>
+          <InputButton
+            onPress={() => {
+              setIsOpen(true);
+              setTempValue(value);
+            }}
+          >
+            <InputText hasValue={value != null}>{getSelectedLabel()}</InputText>
+          </InputButton>
+
+          {/* Modal */}
+          <Modal
+            visible={isOpen}
+            transparent
+            animationType="slide"
+            onRequestClose={handleCancel}
+          >
+            <ModalOverlay onPress={handleCancel}>
+              {/* Picker Container */}
+              <PickerContainer onPress={(e) => e.stopPropagation()}>
+                {/* Toolbar */}
+                <Toolbar>
+                  <ToolbarButton onPress={handleCancel}>
+                    <ToolbarText>취소</ToolbarText>
+                  </ToolbarButton>
+                  <ToolbarButton onPress={handleConfirm}>
+                    <ToolbarTextBold>완료</ToolbarTextBold>
+                  </ToolbarButton>
+                </Toolbar>
+
+                {/* Picker Wheel */}
+                <WheelPicker
+                  data={options}
+                  value={tempValue}
+                  onValueChanged={({ item: { value } }) => {
+                    setTempValue(value);
+                  }}
+                  enableScrollByTapOnItem={true}
+                />
+              </PickerContainer>
+            </ModalOverlay>
+          </Modal>
+        </>
+      }
+    >
       {/* Input Field */}
-      <InputButton
-        onPress={() => {
-          setIsOpen(true);
-          setTempValue(value);
-        }}
-      >
-        <InputText hasValue={value != null}>{getSelectedLabel()}</InputText>
-      </InputButton>
-
-      {/* Modal */}
-      <Modal
-        visible={isOpen}
-        transparent
-        animationType="slide"
-        onRequestClose={handleCancel}
-      >
-        <ModalOverlay onPress={handleCancel}>
-          {/* Picker Container */}
-          <PickerContainer onPress={(e) => e.stopPropagation()}>
-            {/* Toolbar */}
-            <Toolbar>
-              <ToolbarButton onPress={handleCancel}>
-                <ToolbarText>취소</ToolbarText>
-              </ToolbarButton>
-              <ToolbarButton onPress={handleConfirm}>
-                <ToolbarTextBold>완료</ToolbarTextBold>
-              </ToolbarButton>
-            </Toolbar>
-
-            {/* Picker Wheel */}
-            <WheelPicker
-              data={options}
-              value={tempValue}
-              onValueChanged={({ item: { value } }) => {
-                setTempValue(value);
-              }}
-              enableScrollByTapOnItem={true}
-            />
-          </PickerContainer>
-        </ModalOverlay>
-      </Modal>
-    </>
+    </FieldLayout>
   );
 };
 

--- a/packages/app/src/components/common/entities/WheelPickerTextareaField/index.tsx
+++ b/packages/app/src/components/common/entities/WheelPickerTextareaField/index.tsx
@@ -1,0 +1,148 @@
+import styled from "@emotion/native";
+import WheelPicker from "@quidone/react-native-wheel-picker";
+import { COLORS } from "@styles/colorPalette";
+import { useState } from "react";
+import { Modal, Platform } from "react-native";
+
+export interface WheelPickerOption<T = string> {
+  label: string;
+  value: T;
+}
+
+interface WheelPickerProps<T extends string> {
+  options: WheelPickerOption<T>[];
+  value: T | null;
+  onChange: (value: T) => void;
+  placeholder?: string;
+}
+
+const WheelPickerTextareaField = <T extends string>({
+  options = [],
+  value,
+  onChange,
+  placeholder = "선택하세요",
+}: WheelPickerProps<T>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [defaultValue, setDefaultValue] = useState(value);
+
+  const handleConfirm = () => {
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+    onChange(defaultValue!);
+  };
+
+  const getSelectedLabel = () => {
+    const selected = options.find((opt) => opt.value === value);
+    return selected ? selected.label : placeholder;
+  };
+
+  return (
+    <>
+      {/* Input Field */}
+      <InputButton
+        onPress={() => {
+          setIsOpen(true);
+          setDefaultValue(value);
+        }}
+      >
+        <InputText hasValue={value != null}>{getSelectedLabel()}</InputText>
+      </InputButton>
+
+      {/* Modal */}
+      <Modal
+        visible={isOpen}
+        transparent
+        animationType="slide"
+        onRequestClose={handleCancel}
+      >
+        <ModalOverlay onPress={handleCancel}>
+          {/* Picker Container */}
+          <PickerContainer onPress={(e) => e.stopPropagation()}>
+            {/* Toolbar */}
+            <Toolbar>
+              <ToolbarButton onPress={handleCancel}>
+                <ToolbarText>취소</ToolbarText>
+              </ToolbarButton>
+              <ToolbarButton onPress={handleConfirm}>
+                <ToolbarTextBold>완료</ToolbarTextBold>
+              </ToolbarButton>
+            </Toolbar>
+
+            {/* Picker Wheel */}
+            <WheelPicker
+              data={options}
+              value={value}
+              onValueChanged={({ item: { value } }) => {
+                onChange(value);
+              }}
+              enableScrollByTapOnItem={true}
+            />
+          </PickerContainer>
+        </ModalOverlay>
+      </Modal>
+    </>
+  );
+};
+
+// Styled Components
+const InputButton = styled.TouchableOpacity`
+  width: 100%;
+  padding: 12px 16px;
+  background-color: #ffffff;
+  border-width: 1px;
+  border-color: #d1d5db;
+  border-radius: 8px;
+`;
+
+const InputText = styled.Text<{ hasValue: boolean }>`
+  font-size: 16px;
+  color: ${({ hasValue }) => (hasValue ? "#111827" : "#9ca3af")};
+`;
+
+const ModalOverlay = styled.Pressable`
+  flex: 1;
+  background-color: rgba(0, 0, 0, 0.2);
+  justify-content: flex-end;
+`;
+
+const PickerContainer = styled.Pressable`
+  background-color: #ffffff;
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+  ${Platform.OS === "ios" &&
+  `
+    shadow-color: #000;
+    shadow-offset: 0px -2px;
+    shadow-opacity: 0.1;
+    shadow-radius: 8px;
+  `}
+  ${Platform.OS === "android" && "elevation: 8;"}
+`;
+
+const Toolbar = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+  background-color: ${COLORS.primary};
+`;
+
+const ToolbarButton = styled.TouchableOpacity``;
+
+const ToolbarText = styled.Text`
+  font-size: 16px;
+  color: #ffffff;
+`;
+
+const ToolbarTextBold = styled.Text`
+  font-size: 16px;
+  font-weight: 600;
+  color: #ffffff;
+`;
+
+export default WheelPickerTextareaField;

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/BloodTypeField.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/BloodTypeField.tsx
@@ -1,0 +1,16 @@
+import { useProfileModalFormContext } from "@hooks/feature/form/useProfileModalForm";
+import BloodPicker from "@widget/BloodPicker";
+
+const BloodTypeField = () => {
+  const { watch, setValue } = useProfileModalFormContext();
+  return (
+    <BloodPicker
+      value={watch("bloodType")}
+      onChange={(value) => {
+        setValue("bloodType", value);
+      }}
+    />
+  );
+};
+
+export default BloodTypeField;

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/HeightField.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/HeightField.tsx
@@ -1,0 +1,32 @@
+import { useProfileModalFormContext } from "@hooks/feature/form/useProfileModalForm";
+import TextAreaField from "@shared/ui/TextareaField";
+import { Controller } from "react-hook-form";
+
+const HeightField = () => {
+  const { watch } = useProfileModalFormContext();
+
+  return (
+    <Controller
+      name="height"
+      render={({ field: { onChange, value } }) => (
+        <TextAreaField
+          title="키"
+          titleSize={16}
+          titleSpacing={4}
+          titleWeight="semibold"
+          value={value}
+          onChangeText={onChange}
+          helperText={
+            watch("heightHelperState") === "necessary"
+              ? "필수 입력 사항입니다."
+              : ""
+          }
+          helperTextProps={{ color: "error" }}
+          keyboardType="numeric"
+        />
+      )}
+    />
+  );
+};
+
+export default HeightField;

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/NameField.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/NameField.tsx
@@ -1,0 +1,30 @@
+import { useProfileModalFormContext } from "@hooks/feature/form/useProfileModalForm";
+import TextAreaField from "@shared/ui/TextareaField";
+import { Controller } from "react-hook-form";
+
+const NameField = () => {
+  const { watch } = useProfileModalFormContext();
+  return (
+    <Controller
+      name="name"
+      render={({ field: { onChange, value } }) => (
+        <TextAreaField
+          title="이름"
+          titleSize={16}
+          titleSpacing={4}
+          titleWeight="semibold"
+          value={value}
+          onChangeText={onChange}
+          helperText={
+            watch("nameHelperState") === "necessary"
+              ? "필수 입력 사항입니다."
+              : ""
+          }
+          helperTextProps={{ color: "error" }}
+        />
+      )}
+    />
+  );
+};
+
+export default NameField;

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/SubmitButton.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/SubmitButton.tsx
@@ -3,7 +3,11 @@ import useUserPersonalInformationMutation from "@hooks/feature/query/mutate/useU
 import DefaultButton from "@shared/ui/buttons/DefaultButton";
 import { useCallback } from "react";
 
-const SubmitButton = () => {
+interface SubmitButtonProps {
+  closeModal: () => void;
+}
+
+const SubmitButton = ({ closeModal }: SubmitButtonProps) => {
   const { watch, setValue } = useProfileModalFormContext();
   const { mutate: postUserPersonalInfo } = useUserPersonalInformationMutation();
 
@@ -40,8 +44,6 @@ const SubmitButton = () => {
       return;
     }
 
-    const closeModal = watch("closeModal");
-
     postUserPersonalInfo(
       { name, weight, height, bloodType },
       {
@@ -56,7 +58,7 @@ const SubmitButton = () => {
     );
 
     // Submit the form
-  }, [watch]);
+  }, [watch, closeModal, postUserPersonalInfo, setValue]);
   return <DefaultButton title="확인" onPress={handleConfirm} fullWidth />;
 };
 

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/SubmitButton.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/SubmitButton.tsx
@@ -1,9 +1,12 @@
-import DefaultButton from "@components/common/shared/ui/buttons/DefaultButton";
 import { useProfileModalFormContext } from "@hooks/feature/form/useProfileModalForm";
+import useUserPersonalInformationMutation from "@hooks/feature/query/mutate/useUserPersonalInformationMutation";
+import DefaultButton from "@shared/ui/buttons/DefaultButton";
 import { useCallback } from "react";
 
 const SubmitButton = () => {
   const { watch, setValue } = useProfileModalFormContext();
+  const { mutate: postUserPersonalInfo } = useUserPersonalInformationMutation();
+
   const handleConfirm = useCallback(() => {
     const name = watch("name");
     const weight = watch("weight");
@@ -36,6 +39,21 @@ const SubmitButton = () => {
     if (!name || !weight || !height || !bloodType) {
       return;
     }
+
+    const closeModal = watch("closeModal");
+
+    postUserPersonalInfo(
+      { name, weight, height, bloodType },
+      {
+        onSuccess: () => {
+          closeModal();
+        },
+        onError: (error) => {
+          //TODO: error handling
+          console.log(error);
+        },
+      },
+    );
 
     // Submit the form
   }, [watch]);

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/SubmitButton.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/SubmitButton.tsx
@@ -1,0 +1,45 @@
+import DefaultButton from "@components/common/shared/ui/buttons/DefaultButton";
+import { useProfileModalFormContext } from "@hooks/feature/form/useProfileModalForm";
+import { useCallback } from "react";
+
+const SubmitButton = () => {
+  const { watch, setValue } = useProfileModalFormContext();
+  const handleConfirm = useCallback(() => {
+    const name = watch("name");
+    const weight = watch("weight");
+    const height = watch("height");
+    const bloodType = watch("bloodType");
+
+    if (!name) {
+      setValue("nameHelperState", "necessary");
+    } else {
+      setValue("nameHelperState", "none");
+    }
+
+    if (!weight) {
+      setValue("weightHelperState", "necessary");
+    } else {
+      setValue("weightHelperState", "none");
+    }
+
+    if (!height) {
+      setValue("heightHelperState", "necessary");
+    } else {
+      setValue("heightHelperState", "none");
+    }
+    if (!bloodType) {
+      setValue("bloodTypeHelperState", "necessary");
+    } else {
+      setValue("bloodTypeHelperState", "none");
+    }
+
+    if (!name || !weight || !height || !bloodType) {
+      return;
+    }
+
+    // Submit the form
+  }, [watch]);
+  return <DefaultButton title="확인" onPress={handleConfirm} fullWidth />;
+};
+
+export default SubmitButton;

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/WeightField.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/WeightField.tsx
@@ -1,0 +1,32 @@
+import { useProfileModalFormContext } from "@hooks/feature/form/useProfileModalForm";
+import TextAreaField from "@shared/ui/TextareaField";
+import { Controller } from "react-hook-form";
+
+const WeightField = () => {
+  const { watch } = useProfileModalFormContext();
+
+  return (
+    <Controller
+      name="weight"
+      render={({ field: { onChange, value } }) => (
+        <TextAreaField
+          title="몸무게"
+          titleSize={16}
+          titleSpacing={4}
+          titleWeight="semibold"
+          value={value}
+          onChangeText={onChange}
+          helperText={
+            watch("weightHelperState") === "necessary"
+              ? "필수 입력 사항입니다."
+              : ""
+          }
+          helperTextProps={{ color: "error" }}
+          keyboardType="numeric"
+        />
+      )}
+    />
+  );
+};
+
+export default WeightField;

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/index.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/index.tsx
@@ -12,7 +12,6 @@ import HeightField from "./HeightField";
 import NameField from "./NameField";
 import SubmitButton from "./SubmitButton";
 import WeightField from "./WeightField";
-import { useEffect } from "react";
 
 interface HomeProfileModalFormProps {
   closeModal: () => void;
@@ -21,10 +20,6 @@ interface HomeProfileModalFormProps {
 //TODO: section 컴포넌트가 props를 받아서 사용중임. 이는 컨벤션 위반
 const HomeProfileModalForm = ({ closeModal }: HomeProfileModalFormProps) => {
   const form = useProfileModalForm();
-
-  useEffect(() => {
-    form.setValue("closeModal", closeModal);
-  }, [closeModal, form]);
 
   return (
     <OutsideContainer activeOpacity={1}>
@@ -54,7 +49,7 @@ const HomeProfileModalForm = ({ closeModal }: HomeProfileModalFormProps) => {
               <BloodTypeField />
               <Spacing size={18} />
               <ButtonContainer>
-                <SubmitButton />
+                <SubmitButton closeModal={closeModal} />
               </ButtonContainer>
             </FormProvider>
           </ScrollView>

--- a/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/index.tsx
+++ b/packages/app/src/components/feature/screens/Home/HomeProfileModalForm/index.tsx
@@ -1,0 +1,92 @@
+import Spacing from "@components/common/shared/layout/Spacing";
+import Text from "@components/common/shared/ui/Text";
+import styled from "@emotion/native";
+import TextAreaField from "@shared/ui/TextareaField";
+import { COLORS } from "@styles/colorPalette";
+import { KeyboardAvoidingView, Platform, ScrollView } from "react-native";
+
+import { useProfileModalForm } from "@hooks/feature/form/useProfileModalForm";
+import { FormProvider } from "react-hook-form";
+import BloodTypeField from "./BloodTypeField";
+import HeightField from "./HeightField";
+import NameField from "./NameField";
+import SubmitButton from "./SubmitButton";
+import WeightField from "./WeightField";
+import { useEffect } from "react";
+
+interface HomeProfileModalFormProps {
+  closeModal: () => void;
+}
+
+//TODO: section 컴포넌트가 props를 받아서 사용중임. 이는 컨벤션 위반
+const HomeProfileModalForm = ({ closeModal }: HomeProfileModalFormProps) => {
+  const form = useProfileModalForm();
+
+  useEffect(() => {
+    form.setValue("closeModal", closeModal);
+  }, [closeModal, form]);
+
+  return (
+    <OutsideContainer activeOpacity={1}>
+      <ModalContainer>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
+          <ScrollView>
+            <FormProvider {...form}>
+              <Text color="primary" fontWeight="bold" fontSize={24}>
+                위급 시 개인 정보
+              </Text>
+              <Spacing size={18} />
+              <NameField />
+              <Spacing size={18} />
+              <TextAreaField
+                title="전화번호"
+                titleSize={16}
+                titleSpacing={4}
+                titleWeight="semibold"
+              />
+              <Spacing size={18} />
+              <WeightField />
+              <Spacing size={18} />
+              <HeightField />
+              <Spacing size={18} />
+              <BloodTypeField />
+              <Spacing size={18} />
+              <ButtonContainer>
+                <SubmitButton />
+              </ButtonContainer>
+            </FormProvider>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      </ModalContainer>
+    </OutsideContainer>
+  );
+};
+
+const OutsideContainer = styled.TouchableOpacity`
+  flex: 1;
+  background-color: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContainer = styled.View`
+  text-align: center;
+  width: 320px;
+  /* max-height: 80%; */
+  padding: 20px;
+  background-color: ${COLORS.mainWhite};
+  border-radius: 12px;
+`;
+
+const ButtonContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  width: 100%;
+  justify-content: flex-end;
+  align-items: center;
+`;
+
+export default HomeProfileModalForm;

--- a/packages/app/src/components/feature/widget/BloodPicker/index.tsx
+++ b/packages/app/src/components/feature/widget/BloodPicker/index.tsx
@@ -1,0 +1,26 @@
+import WheelPickerTextareaField from "@entities/WheelPickerTextareaField";
+
+const BLOOD_TYPES = ["A", "B", "AB", "O"] as const;
+
+interface BloodPickerProps {
+  value: (typeof BLOOD_TYPES)[number];
+  onChange: (value: (typeof BLOOD_TYPES)[number]) => void;
+}
+
+const BloodPicker = ({ value, onChange }: BloodPickerProps) => {
+  return (
+    <WheelPickerTextareaField
+      options={[
+        { label: "A", value: "A" },
+        { label: "B", value: "B" },
+        { label: "AB", value: "AB" },
+        { label: "O", value: "O" },
+      ]}
+      placeholder="혈액형 선택"
+      onChange={(value) => onChange(value)}
+      value={value}
+    />
+  );
+};
+
+export default BloodPicker;

--- a/packages/app/src/components/feature/widget/BloodPicker/index.tsx
+++ b/packages/app/src/components/feature/widget/BloodPicker/index.tsx
@@ -1,8 +1,13 @@
 import WheelPickerTextareaField from "@entities/WheelPickerTextareaField";
+import { ComponentProps } from "react";
 
 const BLOOD_TYPES = ["A", "B", "AB", "O"] as const;
 
-interface BloodPickerProps {
+interface BloodPickerProps
+  extends Omit<
+    ComponentProps<typeof WheelPickerTextareaField>,
+    "title" | "options"
+  > {
   value: (typeof BLOOD_TYPES)[number];
   onChange: (value: (typeof BLOOD_TYPES)[number]) => void;
 }
@@ -10,6 +15,7 @@ interface BloodPickerProps {
 const BloodPicker = ({ value, onChange }: BloodPickerProps) => {
   return (
     <WheelPickerTextareaField
+      title="혈액형"
       options={[
         { label: "A", value: "A" },
         { label: "B", value: "B" },

--- a/packages/app/src/hooks/feature/authenticate/useCheckUserLoginAndProfileState/index.ts
+++ b/packages/app/src/hooks/feature/authenticate/useCheckUserLoginAndProfileState/index.ts
@@ -7,7 +7,7 @@ const useCheckUserLoginAndProfileState = () => {
   const [refreshToken, setRefreshToken] = useState<string | undefined>();
   const [isCheckingLoginLoading, setIsCheckingLoginLoading] = useState(true);
   const {
-    data: profileStatus,
+    data,
     isLoading: profileStatusLoading,
     error: profileStatusError,
   } = useUserProfileStatusQuery();
@@ -36,7 +36,8 @@ const useCheckUserLoginAndProfileState = () => {
 
   return {
     isLoggedIn: !profileStatusLoading && !!accessToken,
-    isProfileComplete: profileStatus?.isComplete ?? false,
+    isBasicInfoSet: data?.userStatusInfoDTO.isBasicInfoSet,
+    isPersonalInfoSet: data?.userStatusInfoDTO.isPersonalInfoSet,
     isLoading: profileStatusLoading || isCheckingLoginLoading,
     profileStatusLoading,
     isCheckingLoginLoading,

--- a/packages/app/src/hooks/feature/form/useProfileModalForm/index.ts
+++ b/packages/app/src/hooks/feature/form/useProfileModalForm/index.ts
@@ -1,0 +1,32 @@
+import { useForm, useFormContext } from "react-hook-form";
+
+interface ProfileModalFormValues {
+  name: string;
+  weight: number;
+  height: number;
+  bloodType: "A" | "B" | "AB" | "O";
+
+  nameHelperState: "none" | "necessary";
+  weightHelperState: "none" | "necessary";
+  heightHelperState: "none" | "necessary";
+  bloodTypeHelperState: "none" | "necessary";
+}
+
+export const useProfileModalForm = () => {
+  return useForm<ProfileModalFormValues>({
+    defaultValues: {
+      name: "",
+      weight: 0,
+      height: 0,
+      bloodType: "A",
+      nameHelperState: "none",
+      weightHelperState: "none",
+      heightHelperState: "none",
+      bloodTypeHelperState: "none",
+    },
+  });
+};
+
+export const useProfileModalFormContext = () => {
+  return useFormContext<ProfileModalFormValues>();
+};

--- a/packages/app/src/hooks/feature/form/useProfileModalForm/index.ts
+++ b/packages/app/src/hooks/feature/form/useProfileModalForm/index.ts
@@ -10,6 +10,8 @@ interface ProfileModalFormValues {
   weightHelperState: "none" | "necessary";
   heightHelperState: "none" | "necessary";
   bloodTypeHelperState: "none" | "necessary";
+
+  closeModal: () => void;
 }
 
 export const useProfileModalForm = () => {

--- a/packages/app/src/hooks/feature/form/useProfileModalForm/index.ts
+++ b/packages/app/src/hooks/feature/form/useProfileModalForm/index.ts
@@ -10,8 +10,6 @@ interface ProfileModalFormValues {
   weightHelperState: "none" | "necessary";
   heightHelperState: "none" | "necessary";
   bloodTypeHelperState: "none" | "necessary";
-
-  closeModal: () => void;
 }
 
 export const useProfileModalForm = () => {

--- a/packages/app/src/hooks/feature/modal/usePersonalInfoModal/index.tsx
+++ b/packages/app/src/hooks/feature/modal/usePersonalInfoModal/index.tsx
@@ -1,0 +1,18 @@
+import HomeProfileModalForm from "@components/feature/screens/Home/HomeProfileModalForm";
+import useModal from "@service/modal/hooks";
+
+const usePersonalInfoModal = () => {
+  const { openModal, closeModal } = useModal();
+
+  const showNotificationModal = () => {
+    openModal(<HomeProfileModalForm closeModal={closeModal} />, {
+      transparent: true,
+      animationType: "none",
+      hardwareAccelerated: true,
+    });
+  };
+
+  return { showNotificationModal };
+};
+
+export default usePersonalInfoModal;

--- a/packages/app/src/hooks/feature/query/mutate/useUserPersonalInformationMutation/index.ts
+++ b/packages/app/src/hooks/feature/query/mutate/useUserPersonalInformationMutation/index.ts
@@ -1,0 +1,17 @@
+import authenticatedApi from "@api/_instances/authenticatedApi";
+import { useMutation } from "@tanstack/react-query";
+import {
+  postUserPersonalInformation,
+  PostUserPersonalInformationResponse,
+  USER_PERSONAL_INFORMATION_API_PATH,
+} from "api";
+
+const useUserPersonalInformationMutation = () => {
+  return useMutation({
+    mutationKey: [USER_PERSONAL_INFORMATION_API_PATH],
+    mutationFn: (body: PostUserPersonalInformationResponse) =>
+      postUserPersonalInformation(authenticatedApi, body),
+  });
+};
+
+export default useUserPersonalInformationMutation;

--- a/packages/app/src/hooks/feature/query/mutate/useUserPersonalInformationMutation/index.ts
+++ b/packages/app/src/hooks/feature/query/mutate/useUserPersonalInformationMutation/index.ts
@@ -2,14 +2,14 @@ import authenticatedApi from "@api/_instances/authenticatedApi";
 import { useMutation } from "@tanstack/react-query";
 import {
   postUserPersonalInformation,
-  PostUserPersonalInformationResponse,
+  PostUserPersonalInformationRequest,
   USER_PERSONAL_INFORMATION_API_PATH,
 } from "api";
 
 const useUserPersonalInformationMutation = () => {
   return useMutation({
     mutationKey: [USER_PERSONAL_INFORMATION_API_PATH],
-    mutationFn: (body: PostUserPersonalInformationResponse) =>
+    mutationFn: (body: PostUserPersonalInformationRequest) =>
       postUserPersonalInformation(authenticatedApi, body),
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3480,6 +3480,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@quidone/react-native-wheel-picker@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "@quidone/react-native-wheel-picker@npm:1.6.1"
+  dependencies:
+    "@rozhkov/react-useful-hooks": "npm:^1.0.10"
+    date-fns: "npm:^4.1.0"
+  peerDependencies:
+    react: ">=16.8"
+    react-native: ">=0.71.6"
+  checksum: 10c0/8bb8d11fb685195576a6f337ab06ae75b52ceb0ab362bc4247aa74c00748be9ec5b9ebd0e87dc185aad0ed4dc88e77dd01703b1c2e56e55c9fb716df8116deca
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-compose-refs@npm:1.1.2":
   version: 1.1.2
   resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
@@ -4152,6 +4165,17 @@ __metadata:
   version: 4.52.3
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.52.3"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rozhkov/react-useful-hooks@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "@rozhkov/react-useful-hooks@npm:1.0.10"
+  dependencies:
+    default-values: "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.8 || ^17 || ^18 || ^19
+  checksum: 10c0/943022d5b900cd400ca42a0ff7a828b1ef91ca76d86bcd5c078ea4b0e43cd7b827706b2caa5513d4656598144a50479db0c88d332c01cb39a67208f6686c45c5
   languageName: node
   linkType: hard
 
@@ -5880,6 +5904,7 @@ __metadata:
     "@expo/cli": "npm:0.24.20"
     "@expo/vector-icons": "npm:^14.1.0"
     "@mj-studio/react-native-naver-map": "npm:^2.6.1"
+    "@quidone/react-native-wheel-picker": "npm:^1.6.1"
     "@react-native-async-storage/async-storage": "npm:2.1.2"
     "@react-native-voice/voice": "npm:^3.2.4"
     "@react-navigation/bottom-tabs": "npm:^7.2.0"
@@ -7387,6 +7412,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
+  languageName: node
+  linkType: hard
+
 "debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -7468,6 +7500,13 @@ __metadata:
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
+"default-values@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "default-values@npm:1.0.2"
+  checksum: 10c0/f785452cdbb9ef81fd8660e0001f0bd22a6692a63b8b8fb515d5757fe59bfe9af26910c3239d7693d5bc992afcb2431f55da5cc4c8b78651ed179d81125edc08
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- #20

위급시 개인 정보 모달을 구현하였습니다.


<div align="center">
<img width="25%" src="https://github.com/user-attachments/assets/43f422a7-7325-4fad-8102-7de17cd03628"/>
</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 개인정보 입력 모달 추가: 이름·키·몸무게·혈액형 입력 폼 및 제출 버튼
  - 휠 피커 기반 혈액형 선택 위젯 및 범용 휠 피커 입력 필드 추가
  - 홈 탭에서 개인정보 미작성 시 안내 모달 자동 표시
  - 개인정보 등록용 공개 API 경로 추가

- **Improvements**
  - 프로필 상태 응답 형식 변경: 기본/개인정보 설정 여부가 명확한 플래그로 분리되어 처리됨
  - 로그인/리다이렉트 로직이 기본정보(isBasicInfoSet) 기준으로 개선

- **Bug Fixes**
  - 일부 알림 설정 응답 구조 정렬 및 불필요 필드 제거

- **Chores**
  - 휠 피커 라이브러리 의존성 추가 (@quidone/react-native-wheel-picker)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->