### PR TITLE
[FIX] baseURL 환경변수값의 여부를 바로 알 수 있도록 예외 로직 추가

### DIFF
--- a/packages/web/src/api/_instances/authenticatedApi/index.ts
+++ b/packages/web/src/api/_instances/authenticatedApi/index.ts
@@ -2,8 +2,12 @@ import { isInStackFrame } from "stack-link";
 import { ErrorResponse } from "@/types/api";
 import axios, { AxiosError, AxiosResponse } from "axios";
 
+const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
+
+if (!baseURL) throw new Error("NEXT_PUBLIC_BASE_URL env값이 없습니다");
+
 const authenticatedApi = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, ""),
+  baseURL: baseURL?.replace(/\/$/, ""),
   timeout: 5000,
   headers:
     process.env.NODE_ENV === "development"

--- a/packages/web/src/api/_instances/authenticatedApi/index.ts
+++ b/packages/web/src/api/_instances/authenticatedApi/index.ts
@@ -7,7 +7,7 @@ const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
 if (!baseURL) throw new Error("NEXT_PUBLIC_BASE_URL env값이 없습니다");
 
 const authenticatedApi = axios.create({
-  baseURL: baseURL?.replace(/\/$/, ""),
+  baseURL: baseURL.replace(/\/$/, ""),
   timeout: 5000,
   headers:
     process.env.NODE_ENV === "development"

--- a/packages/web/src/api/_instances/publicApi/index.ts
+++ b/packages/web/src/api/_instances/publicApi/index.ts
@@ -1,8 +1,12 @@
 import { ErrorResponse } from "@/types/api";
 import axios, { AxiosError, AxiosResponse } from "axios";
 
+const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
+
+if (!baseURL) throw new Error("NEXT_PUBLIC_BASE_URL env값이 없습니다");
+
 const publicApi = axios.create({
-  baseURL: `${process.env.NEXT_PUBLIC_BASE_URL}`?.replace(/\/$/, ""),
+  baseURL: baseURL.replace(/\/$/, ""),
   timeout: 5000,
   headers:
     process.env.NODE_ENV === "development"
@@ -24,7 +28,7 @@ publicApi.interceptors.response.use(
   async (error: AxiosError<ErrorResponse>) => {
     const err = Object.assign(
       new Error(
-        error.response?.data?.message || "알 수 없는 오류가 발생했습니다."
+        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
       ),
       {
         name: "ApiError",
@@ -33,12 +37,12 @@ publicApi.interceptors.response.use(
         httpStatus: error.response?.status,
         url: error.config?.url,
         cause: error,
-      }
+      },
     ) as Error &
       ErrorResponse & { httpStatus?: number; url?: string; cause?: unknown };
 
     return Promise.reject(err);
-  }
+  },
 );
 
 export default publicApi;


### PR DESCRIPTION
#31

baseURL 환경변수값의 설정 여부를 바로 알 수 있도록 예외 로직을 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * API 초기화 시 필수 구성값 검증을 추가하여 환경 설정 누락에 따른 초기화 실패를 사전 차단, 서비스 안정성 향상
  * 인증 및 공개 API의 에러 응답에 명확한 상태와 표준화된 에러 코드 필드를 추가하여 문제 진단 및 처리 용이성 개선
  * 기존 요청/응답 인터셉터 동작은 유지하면서 전체적인 API 통신의 일관성 및 신뢰성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->