### PR TITLE
[FEAT] 카카오 로그인시 토큰이 앱에 저장되지 않던 버그 수정

### DIFF
--- a/packages/app/src/components/feature/widget/LoginWebView/index.tsx
+++ b/packages/app/src/components/feature/widget/LoginWebView/index.tsx
@@ -17,10 +17,10 @@ const LoginWebView = () => {
             typeof body !== "object" ||
             !("accessToken" in body) ||
             !("refreshToken" in body) ||
-            !("accessTokenExpiredTime" in body) ||
+            !("expiredTime" in body) ||
             typeof body.accessToken !== "string" ||
             typeof body.refreshToken !== "string" ||
-            typeof body.accessTokenExpiredTime !== "number"
+            typeof body.expiredTime !== "number"
           ) {
             console.error("Invalid token data received");
             return {
@@ -29,11 +29,11 @@ const LoginWebView = () => {
               message: "Invalid token data received",
             };
           }
-          const { accessToken, refreshToken, accessTokenExpiredTime } = body;
+          const { accessToken, refreshToken, expiredTime } = body;
 
           setAccessToken(accessToken);
           setRefreshToken(refreshToken);
-          setAccessTokenExpiredTime(accessTokenExpiredTime);
+          setAccessTokenExpiredTime(expiredTime);
 
           router.dismissAll();
           router.replace("/");

--- a/packages/web/src/hooks/common/useSendToken/index.ts
+++ b/packages/web/src/hooks/common/useSendToken/index.ts
@@ -27,9 +27,7 @@ const useSendToken = () => {
       return;
     }
 
-    const expiredTimeNumber = Number(searchParams.get("expiredTime"));
-
-    if (expiredTimeNumber === undefined || isNaN(expiredTimeNumber)) {
+    if (expiredTime === undefined || isNaN(+expiredTime)) {
       console.error("Invalid accessTokenExpiredTime");
       showToast({
         type: "error",

--- a/packages/web/src/hooks/common/useSendToken/index.ts
+++ b/packages/web/src/hooks/common/useSendToken/index.ts
@@ -1,4 +1,5 @@
 import useRouteBackBridge from "@/hooks/feature/bridge/useRouteBackBridge";
+import useShowToastBridge from "@/hooks/feature/bridge/useShowToastBridge";
 import { useBridge } from "bridge/web";
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
@@ -8,23 +9,34 @@ const useSendToken = () => {
   const { request } = useBridge();
 
   const goBack = useRouteBackBridge();
+  const showToast = useShowToastBridge();
 
   const accessToken = searchParams.get("accessToken");
   const refreshToken = searchParams.get("refreshToken");
-  const accessTokenExpiredTime = searchParams.get("accessTokenExpiredTime");
+  const expiredTime = searchParams.get("expiredTime");
 
   useEffect(() => {
-    if (!accessToken || !refreshToken || !accessTokenExpiredTime) {
+    if (!accessToken || !refreshToken || !expiredTime) {
       console.error("Missing token parameters");
+      showToast({
+        type: "error",
+        text1: "카카오 로그인 실패",
+        text2: "시스템상 문제가 발생했습니다. 다시 시도해주세요.",
+      });
+      goBack();
       return;
     }
 
-    const expiredTime = accessTokenExpiredTime
-      ? Number(accessTokenExpiredTime)
-      : undefined;
+    const expiredTimeNumber = Number(searchParams.get("expiredTime"));
 
-    if (expiredTime === undefined || isNaN(expiredTime)) {
+    if (expiredTimeNumber === undefined || isNaN(expiredTimeNumber)) {
       console.error("Invalid accessTokenExpiredTime");
+      showToast({
+        type: "error",
+        text1: "카카오 로그인 실패",
+        text2: "시스템상 문제가 발생했습니다. 다시 시도해주세요.",
+      });
+      goBack();
       return;
     }
 
@@ -35,12 +47,12 @@ const useSendToken = () => {
         body: {
           accessToken,
           refreshToken,
-          accessTokenExpiredTime: expiredTime,
+          expiredTime,
         },
       },
     });
     goBack();
-  }, [accessToken, accessTokenExpiredTime, goBack, refreshToken, request]);
+  }, [accessToken, expiredTime, goBack, refreshToken, request]);
 };
 
 export default useSendToken;

--- a/packages/web/src/hooks/feature/authenticate/useSaveAuthToken/index.ts
+++ b/packages/web/src/hooks/feature/authenticate/useSaveAuthToken/index.ts
@@ -7,11 +7,13 @@ const useSaveAuthToken = () => {
 
   const accessToken = searchParams.get("accessToken");
   const refreshToken = searchParams.get("refreshToken");
+  const expiredTime = searchParams.get("expiredTime");
 
   useEffect(() => {
     if (accessToken && refreshToken) {
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
+      localStorage.setItem("expiredTime", expiredTime);
     }
   }, [accessToken, refreshToken, router]);
 };

--- a/packages/web/src/hooks/feature/authenticate/useSaveAuthToken/index.ts
+++ b/packages/web/src/hooks/feature/authenticate/useSaveAuthToken/index.ts
@@ -10,12 +10,12 @@ const useSaveAuthToken = () => {
   const expiredTime = searchParams.get("expiredTime");
 
   useEffect(() => {
-    if (accessToken && refreshToken) {
+    if (accessToken && refreshToken && expiredTime) {
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
       localStorage.setItem("expiredTime", expiredTime);
     }
-  }, [accessToken, refreshToken, router]);
+  }, [accessToken, refreshToken, router, expiredTime]);
 };
 
 export default useSaveAuthToken;


### PR DESCRIPTION
- #27

기존에 카카오 로그인시 올바르게 리다이렉트는 되지만 해당 값에서 만료 시간을 올바르게 가져오지 못하여 토큰을 올바르게 저장하지 못하는 문제를 해결하였습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 토큰 검증 실패 시 사용자에게 한국어 안내 토스트가 표시됩니다.
  * 토큰 만료 시간 처리가 일관되게 개선되어 만료 판정이 더 정확해졌습니다.
  * 인증 오류 발생 시 자동으로 이전 페이지로 돌아가도록 동작합니다.
  * 인증 처리 흐름에서 만료 시간이 저장되어 세션 만료 관리가 안정화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->