### PR TITLE
[FEAT] 기록 상세 페이지에서 사용자의 기록정보 지도 구현

### DIFF
--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -809,7 +809,7 @@
       "responses": [
         {
           "uuid": "09ead24d-543b-4e53-8eeb-36828d6a560e",
-          "body": "{\n  \"data\": { \n    \"recordId\": 12,\n    \"displayName\": \"새인봉 - 서석대\",\n    \"startedAt\": 1759152556,\n    \"endAt\": 1759152556,\n    \"duration\": 21123410,\n    \"length\": 6.2,\n    \"coordinates\": [\n      [127.12345678901234, 37.12345678901234],\n      [127.12345978901233, 37.12345678901234]\n    ],\n    \"courseId\": 6,\n    \"mountainId\": 1\n  },\n  \"status\": \"success\"\n}",
+          "body": "{\n  \"data\": { \n    \"recordId\": 12,\n    \"displayName\": \"새인봉 - 서석대\",\n    \"startedAt\": 1759152556,\n    \"endAt\": 1759152556,\n    \"duration\": 21123410,\n    \"length\": 6.2,\n    \"coordinates\": [\n      [127.12345678901234, 37.12345678901234],\n      [127.12345978911233, 37.13345678901234],\n      [127.12345978911233, 39.13345678901234]\n    ],\n    \"courseId\": 6,\n    \"mountainId\": 1\n  },\n  \"status\": \"success\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",

--- a/packages/web/src/components/features/pages/my-info/TravelLogDetailContentSection/index.tsx
+++ b/packages/web/src/components/features/pages/my-info/TravelLogDetailContentSection/index.tsx
@@ -8,6 +8,17 @@ import Spacing from "@shared/layout/Spacing";
 import { Suspense } from "@suspensive/react";
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
+import dynamic from "next/dynamic";
+
+const TravelResultPathMapView = dynamic(
+  () =>
+    import(
+      "@/components/features/widgets/map/TravelResultPathMapView/index"
+    ).then((mod) => mod.default),
+  {
+    ssr: false,
+  },
+);
 
 import TravelLogDetailContentSectionLoader from "./loader";
 
@@ -44,7 +55,9 @@ const TravelLogDetailContentSection = Suspense.with(
           </span>
         </div>
         <Spacing size={3.5} />
-        <div className="h-80 bg-gray-100"></div>
+        <div className="h-80 bg-gray-100 select-none">
+          <TravelResultPathMapView traveledPath={coordinates} />
+        </div>
         <div className="flex">
           <div className="grow p-3.5">
             <p className="text-2xl font-bold text-center">

--- a/packages/web/src/components/features/widgets/map/TravelResultPathMapView/index.tsx
+++ b/packages/web/src/components/features/widgets/map/TravelResultPathMapView/index.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import useCalculateCameraPosition from "@hooks/feature/map/useCalculateCameraPosition";
+import useNaverMap from "@hooks/feature/map/useNaverMap";
+import useDrawPath from "@hooks/feature/map/useDrawPath";
+import { useEffect, useMemo } from "react";
+
+interface TravelResultPathMapViewProps {
+  /**
+   * [longitude, latitude] 형식의 좌표 배열
+   */
+  traveledPath: [number, number][];
+}
+
+/**
+ * 산행 결과 화면용 지도 컴포넌트
+ * - 전체 경로를 화면에 맞게 표시
+ * - 사용자 상호작용(줌, 회전, 스크롤) 불가
+ * - 하단 UI 영역을 피하도록 카메라 위치 조정
+ */
+export default function TravelResultPathMapView({
+  traveledPath,
+}: TravelResultPathMapViewProps) {
+  const cameraPosition = useCalculateCameraPosition(traveledPath);
+
+  const { map, mapId } = useNaverMap({
+    latitude: cameraPosition.latitude,
+    longitude: cameraPosition.longitude,
+    zoom: cameraPosition.zoom,
+  });
+
+  // 시작점과 끝점 계산
+  const basePoints = useMemo(() => {
+    if (traveledPath.length >= 2) {
+      return [
+        { latitude: traveledPath[0][1], longitude: traveledPath[0][0] }, // 시작점
+        {
+          latitude: traveledPath[traveledPath.length - 1][1],
+          longitude: traveledPath[traveledPath.length - 1][0],
+        }, // 끝점
+      ];
+    } else if (traveledPath.length === 1) {
+      return [{ latitude: traveledPath[0][1], longitude: traveledPath[0][0] }];
+    }
+    return [];
+  }, [traveledPath]);
+
+  // 경로를 폴리라인으로 표시
+  const paths =
+    traveledPath.length > 0
+      ? [
+          {
+            path: traveledPath,
+            strokeWeight: 6,
+            strokeColor: "#2B7552",
+            strokeOpacity: 1,
+          },
+        ]
+      : [];
+
+  useDrawPath({
+    map,
+    paths,
+    enable: paths.length > 0,
+  });
+
+  // 시작점과 끝점에 원(마커) 그리기
+  useEffect(() => {
+    if (!map || basePoints.length === 0) return;
+
+    basePoints.forEach((point) => {
+      const center = new naver.maps.LatLng(point.latitude, point.longitude);
+
+      // 바깥쪽 원 (primary 색상)
+      new naver.maps.Circle({
+        map,
+        center,
+        radius: 2,
+        fillColor: "#2B7552",
+        fillOpacity: 1,
+        strokeColor: "transparent",
+        strokeWeight: 0,
+      });
+
+      // 안쪽 원 (흰색)
+      new naver.maps.Circle({
+        map,
+        center,
+        radius: 1,
+        fillColor: "#fff",
+        fillOpacity: 1,
+        strokeColor: "transparent",
+        strokeWeight: 0,
+      });
+    });
+  }, [map, basePoints]);
+
+  // 모든 제스처 비활성화
+  useEffect(() => {
+    if (!map) return;
+
+    // 네이버맵 제스처 비활성화
+    map.setOptions({
+      draggable: false,
+      pinchZoom: false,
+      scrollWheel: false,
+      keyboardShortcuts: false,
+    });
+  }, [map]);
+
+  return <div id={mapId} className="h-full w-full" />;
+}

--- a/packages/web/src/hooks/feature/map/useCalculateCameraPosition/index.ts
+++ b/packages/web/src/hooks/feature/map/useCalculateCameraPosition/index.ts
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+
+interface CameraPosition {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+}
+
+/**
+ * 경로 배열을 기반으로 전체 경로를 볼 수 있는 카메라 위치와 줌 레벨을 계산합니다.
+ * 모바일 앱의 TravelResultMapView 로직을 따릅니다.
+ *
+ * @param traveledPath - [longitude, latitude] 형식의 좌표 배열
+ * @returns 카메라 중심점(latitude, longitude)과 줌 레벨
+ */
+const useCalculateCameraPosition = (traveledPath: [number, number][]) => {
+  const cameraPosition: CameraPosition = useMemo(() => {
+    // 경로가 없는 경우
+    if (traveledPath.length === 0) {
+      return { latitude: 0, longitude: 0, zoom: 15 };
+    }
+
+    // 경도와 위도 범위 계산
+    const latitudes = traveledPath.map(([, latitude]) => latitude);
+    const longitudes = traveledPath.map(([longitude]) => longitude);
+
+    const maxLat = Math.max(...latitudes);
+    const minLat = Math.min(...latitudes);
+    const maxLng = Math.max(...longitudes);
+    const minLng = Math.min(...longitudes);
+
+    // 중심점 계산
+    const centerLat = (maxLat + minLat) / 2;
+    const centerLng = (maxLng + minLng) / 2;
+
+    // 위도 범위
+    const latRange = maxLat - minLat;
+
+    // 하단 UI(바텀시트) 회피를 위한 오프셋 (모바일: 40%)
+    const offsetFactor = 0.4;
+    const latOffset = latRange * offsetFactor;
+
+    // 줌 레벨 계산
+    const latitudeDiff = latRange;
+    const longitudeDiff = maxLng - minLng;
+
+    // 패딩을 고려한 범위
+    const paddedLatDiff = latitudeDiff * 25001;
+    const paddedLngDiff = longitudeDiff * 25001;
+
+    // 로그 기반 줌 계산
+    const latZoom = Math.max(1, 22 - Math.log2(paddedLatDiff));
+    const lngZoom = Math.max(1, 22 - Math.log2(paddedLngDiff));
+
+    const zoom = Math.min(latZoom, lngZoom);
+    const finalZoom = Math.min(20, Math.max(1, zoom));
+
+    return {
+      latitude: centerLat - latOffset,
+      longitude: centerLng,
+      zoom: finalZoom,
+    };
+  }, [traveledPath]);
+
+  return cameraPosition;
+};
+
+export default useCalculateCameraPosition;


### PR DESCRIPTION
기록 상세 페이지에서 사용자의 기록정보 지도를 구현하였습니다

<img width="411" height="783" alt="image" src="https://github.com/user-attachments/assets/1620f9eb-88ba-4eab-a075-6ae66ebf1c7d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 여행 기록 상세 페이지에 경로 지도 시각화 추가
  * 여행한 경로를 지도상에 선으로 표시
  * 출발점과 도착점을 마커로 표현
  * 지도 상호작용 비활성화로 읽기 전용 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->