### PR TITLE
[FEAT] CICD 파이프라인 호출 로직 추가

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,0 +1,39 @@
+name: Dispatch Frontend Deploy
+
+on:
+  push:
+    branches: ["develop"]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Infra Repo Deploy
+        run: |
+          REPO="${{ github.repository }}"
+          BRANCH="${{ github.ref_name }}"
+          COMMIT="${{ github.sha }}"
+          AUTHOR="${{ github.actor }}"
+          PUSHED_AT="${{ github.event.head_commit.timestamp }}"
+
+          DISPATCH_JSON=$(jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg commit "$COMMIT" \
+            --arg author "$AUTHOR" \
+            --arg pushed_at "$PUSHED_AT" \
+            '{event_type: "fe-deploy", client_payload: {
+                repo: $repo,
+                branch: $branch,
+                commit: $commit,
+                author: $author,
+                pushed_at: $pushed_at
+              }}')
+
+          curl -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.INFRA_GH_PAT }}" \
+            https://api.github.com/repos/${{ secrets.INFRA_REPO_OWNER }}/${{ secrets.INFRA_REPO_NAME }}/dispatches \
+            -d "${DISPATCH_JSON}"

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -32,8 +32,10 @@ jobs:
               }}')
 
           curl -s \
+            --fail \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.INFRA_GH_PAT }}" \
             https://api.github.com/repos/${{ secrets.INFRA_REPO_OWNER }}/${{ secrets.INFRA_REPO_NAME }}/dispatches \
-            -d "${DISPATCH_JSON}"
+            -d "${DISPATCH_JSON}" \
+            || { echo "Failed to trigger dispatch"; exit 1; }


### PR DESCRIPTION
- #42 

인프라 레포의 CICD 파이프라인을 호출하도록 workflow를 구성하였습니다.
프론트 레포의 커밋 히스토리를 어지럽히지 않게, 책임을 분리하여 필요한 정보만 CICD 파이프라인에 넘기고
인프라 레포의 CICD에서 처리하도록 구성하였습니다.

필요한 정보:
- 레포 이름
- 브랜치
- 커밋해시
- 작성자
- 푸시된 시간

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 개발 브랜치 푸시 시 자동화된 프런트엔드 배포 워크플로우 추가.
  * 배포 대상 리포지토리로 배포 요청(disptach)을 전송하고, 전송 실패 시 명확한 오류 처리 및 실패로 표시되도록 구성.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->