### PR TITLE
[FEAT] 이용 약관 페이지 ui 구현

### DIFF
--- a/packages/app/src/app/index.tsx
+++ b/packages/app/src/app/index.tsx
@@ -57,7 +57,7 @@ export default function Index() {
   }
 
   if (isLoggedIn && !isBasicInfoSet)
-    return <Redirect href="/onboarding/profile" />;
+    return <Redirect href="/onboarding/terms" />;
 
   if (accessToken) return <Redirect href="/(tabs)/home" />;
   return <Redirect href={"/starter"} />;

--- a/packages/app/src/app/onboarding/terms.tsx
+++ b/packages/app/src/app/onboarding/terms.tsx
@@ -1,0 +1,20 @@
+import TermListSection from "@screens/terms/TermListSection";
+import TermsDescriptionSection from "@screens/terms/TermsDescriptionSection";
+import TermsHeaderSection from "@screens/terms/TermsHeaderSection";
+import ScreenContainer from "@shared/layout/Screen";
+import Spacing from "@shared/layout/Spacing";
+
+const TermsScreen = () => {
+  return (
+    <ScreenContainer>
+      <Spacing size={18} />
+      <TermsHeaderSection />
+      <Spacing size={32} />
+      <TermsDescriptionSection />
+      <Spacing size={20} />
+      <TermListSection />
+    </ScreenContainer>
+  );
+};
+
+export default TermsScreen;

--- a/packages/app/src/components/common/shared/ui/Header/index.tsx
+++ b/packages/app/src/components/common/shared/ui/Header/index.tsx
@@ -16,12 +16,12 @@ const Header = ({
   paddingBlock,
   paddingInline,
   headerTitle,
-  headerLeft,
+  headerLeft = true,
   headerRight,
 }: HeaderProps) => {
   return (
     <Container paddingBlock={paddingBlock} paddingInline={paddingInline}>
-      <HeaderItem>{headerLeft || <BackButton />}</HeaderItem>
+      <HeaderItem>{headerLeft && <BackButton />}</HeaderItem>
       <HeaderItem>
         <Text textAlign="center" fontSize={18} fontWeight="semibold">
           {headerTitle}

--- a/packages/app/src/components/common/shared/ui/ListItemCard/index.tsx
+++ b/packages/app/src/components/common/shared/ui/ListItemCard/index.tsx
@@ -1,12 +1,8 @@
 import styled from "@emotion/native";
-import {
-  ChosenTriangle,
-  PointerPolygon,
-  WeekGreenTriangle,
-  WeekTriangle,
-} from "@shared/ui/Icons";
+import { PointerPolygon } from "@shared/ui/Icons";
 import Text from "@shared/ui/Text";
 import { COLORS } from "@styles/colorPalette";
+import TriangleCheckbox from "../TriangleCheckbox";
 
 interface ListItemCardProps {
   title: string;
@@ -40,15 +36,7 @@ const ListItemCard = ({
             필수
           </Text>
         </PermissionListItemTextContainer>
-        {!checked ? (
-          disabled ? (
-            <WeekTriangle />
-          ) : (
-            <WeekGreenTriangle />
-          )
-        ) : (
-          <ChosenTriangle />
-        )}
+        <TriangleCheckbox disabled={disabled} checked={checked} />
       </PermissionListItem>
       {selected && (
         <PointerPolygon style={{ transform: [{ translateX: 10 }] }} />

--- a/packages/app/src/components/common/shared/ui/TriangleCheckbox/index.tsx
+++ b/packages/app/src/components/common/shared/ui/TriangleCheckbox/index.tsx
@@ -1,0 +1,34 @@
+import {
+  ChosenTriangle,
+  WeekGreenTriangle,
+  WeekTriangle,
+} from "@shared/ui/Icons";
+import { TouchableOpacity } from "react-native";
+
+interface TriangleCheckboxProps {
+  disabled?: boolean;
+  checked?: boolean;
+  onPress?: () => void;
+}
+
+const TriangleCheckbox = ({
+  disabled = false,
+  checked = false,
+  onPress,
+}: TriangleCheckboxProps) => {
+  return (
+    <TouchableOpacity onPress={onPress} disabled={disabled}>
+      {!checked ? (
+        disabled ? (
+          <WeekTriangle />
+        ) : (
+          <WeekGreenTriangle />
+        )
+      ) : (
+        <ChosenTriangle />
+      )}
+    </TouchableOpacity>
+  );
+};
+
+export default TriangleCheckbox;

--- a/packages/app/src/components/feature/screens/terms/TermListItemCard/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermListItemCard/index.tsx
@@ -1,0 +1,47 @@
+import styled from "@emotion/native";
+import Text from "@shared/ui/Text";
+import TriangleCheckbox from "@shared/ui/TriangleCheckbox";
+
+interface TermListItemCardProps {
+  title: string;
+  description?: string;
+  content?: React.ReactNode;
+  checked: boolean;
+  onPress?: () => void;
+}
+
+const TermListItemCard = ({
+  title,
+  description,
+  content,
+  checked,
+  onPress,
+}: TermListItemCardProps) => {
+  return (
+    <ListContainer>
+      <TriangleCheckbox checked={checked} onPress={onPress} />
+      <ListContentContainer>
+        <Text fontSize={20} fontWeight="normal" color="black">
+          {title}
+        </Text>
+        {description && (
+          <Text fontSize={12} fontWeight="normal" color="gray900">
+            {description}
+          </Text>
+        )}
+        {content && content}
+      </ListContentContainer>
+    </ListContainer>
+  );
+};
+const ListContainer = styled.View`
+  gap: 12px;
+  flex-direction: row;
+`;
+
+const ListContentContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+`;
+
+export default TermListItemCard;

--- a/packages/app/src/components/feature/screens/terms/TermListSection/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermListSection/index.tsx
@@ -1,0 +1,79 @@
+import styled from "@emotion/native";
+import TermListItemCard from "@screens/terms/TermListItemCard";
+import Spacing from "@shared/layout/Spacing";
+import Text from "@shared/ui/Text";
+import { COLORS } from "@styles/colorPalette";
+import { useState } from "react";
+import TermSubmitButton from "../TermSubmitButton";
+
+const TermListSection = () => {
+  const [require1, setRequire1] = useState(false);
+  const [require2, setRequire2] = useState(false);
+  const [require3, setRequire3] = useState(false);
+  const [optional, setOptional] = useState(false);
+  return (
+    <>
+      <Container>
+        <TermListItemCard
+          title="전체 동의"
+          content={
+            <>
+              <Spacing size={18} />
+              <Text fontSize={14} fontWeight="normal" color="gray900">
+                전체동의는 필수 및 선택정보에 대한 동의도
+              </Text>
+              <Text fontSize={14} fontWeight="normal" color="gray900">
+                포함되어 있으며 개별적으로도 동의를 선택할 수 있습니다.
+              </Text>
+            </>
+          }
+          checked={require1 && require2 && require3 && optional}
+          onPress={() => {
+            const newValue = !(require1 && require2 && require3 && optional);
+            setRequire1(newValue);
+            setRequire2(newValue);
+            setRequire3(newValue);
+            setOptional(newValue);
+          }}
+        />
+      </Container>
+      <Spacing size={12} />
+      <Divider />
+      <Spacing size={12} />
+      <Container>
+        <TermListItemCard
+          title="[필수] 이용약관 동의"
+          checked={require1}
+          onPress={() => setRequire1(!require1)}
+        />
+        <TermListItemCard
+          title="[필수] 개인정보 및 민감정보 수집·이용 동의"
+          checked={require2}
+          onPress={() => setRequire2(!require2)}
+        />
+        <TermListItemCard
+          title="[필수] 위치정보 수집·이용 동의"
+          checked={require3}
+          onPress={() => setRequire3(!require3)}
+        />
+        <TermListItemCard
+          title="[선택] 광고성 정보 및 마케팅 활용 동의"
+          checked={optional}
+          onPress={() => setOptional(!optional)}
+        />
+      </Container>
+      <TermSubmitButton disabled={!(require1 && require2 && require3)} />
+    </>
+  );
+};
+
+const Container = styled.View`
+  padding-inline: 24px;
+  gap: 24px;
+`;
+
+const Divider = styled.View`
+  height: 6px;
+  background-color: ${COLORS.gray500};
+`;
+export default TermListSection;

--- a/packages/app/src/components/feature/screens/terms/TermSubmitButton/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermSubmitButton/index.tsx
@@ -1,0 +1,25 @@
+import PositionBottom from "@shared/layout/PositionBottom";
+import DefaultButton from "@shared/ui/buttons/DefaultButton";
+import { router } from "expo-router";
+
+interface TermSubmitButtonProps {
+  disabled?: boolean;
+}
+
+const TermSubmitButton = ({ disabled }: TermSubmitButtonProps) => {
+  const handlePress = () => {
+    router.push("/onboarding/profile");
+  };
+  return (
+    <PositionBottom>
+      <DefaultButton
+        title="확인"
+        onPress={handlePress}
+        fullWidth
+        disabled={disabled}
+      />
+    </PositionBottom>
+  );
+};
+
+export default TermSubmitButton;

--- a/packages/app/src/components/feature/screens/terms/TermsDescriptionSection/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermsDescriptionSection/index.tsx
@@ -1,0 +1,24 @@
+import styled from "@emotion/native";
+import Text from "@shared/ui/Text";
+
+const TermsDescriptionSection = () => {
+  return (
+    <Container>
+      <Text fontWeight="semibold" fontSize={30} color="primary">
+        환영합니다!
+      </Text>
+      <Text fontWeight="semibold" fontSize={30} color="primary">
+        아래 약관에 동의하시면
+      </Text>
+      <Text fontWeight="semibold" fontSize={30} color="primary">
+        안전한 산행이 시작됩니다
+      </Text>
+    </Container>
+  );
+};
+
+const Container = styled.View`
+  padding-inline: 24px;
+`;
+
+export default TermsDescriptionSection;

--- a/packages/app/src/components/feature/screens/terms/TermsHeaderSection/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermsHeaderSection/index.tsx
@@ -1,0 +1,7 @@
+import Header from "@shared/ui/Header";
+
+const TermsHeaderSection = () => {
+  return <Header headerTitle="이용 약관" headerLeft={false} />;
+};
+
+export default TermsHeaderSection;

--- a/packages/app/src/hooks/feature/modal/useBreakwayAlertModal/index.tsx
+++ b/packages/app/src/hooks/feature/modal/useBreakwayAlertModal/index.tsx
@@ -54,7 +54,7 @@ const ModalComponent = () => {
     <OutsideContainer activeOpacity={1}>
       <ModalContainer>
         <Spacing size={14} />
-        <Icon source={require("@assets/icons/alert/Alert_Message.png")} />
+        <Icon source={require("@assets/images/Alert_Message.png")} />
         <Spacing size={18} />
         <Title>
           <Emphasis>경로를 이탈</Emphasis>하였습니다.


### PR DESCRIPTION
- #57 

## 주요 변경사항
이용 약관 페이지 ui를 구현하였습니다. 

<div align="center" width="25%">
<img width="25%" src="https://github.com/user-attachments/assets/932adcdd-e66d-4389-8ddd-5dca9c08810e" />
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이용 약관 동의 화면이 추가되었습니다.
  * 회원가입 흐름 중 약관 동의 단계가 포함되어 있습니다.
  * 필수 약관과 선택 약관을 구분하여 동의받습니다.

* **버그 수정**
  * 알림 모달의 이미지 경로가 수정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->