### PR TITLE
[FEAT] 코스 상세 정보 페이지에서 더 이상 사용하지 않는 하단 초록색 버튼 제거

### DIFF
--- a/packages/web/src/components/features/pages/map/CourseWeatherClothesInfoSection/index.tsx
+++ b/packages/web/src/components/features/pages/map/CourseWeatherClothesInfoSection/index.tsx
@@ -52,7 +52,7 @@ export default Suspense.with(
               {recommendedOutfit ?? "추천 복장"}
             </p>
             <p className="text-xs text-black-800">긴팔 긴바지 착용 권장</p>
-            <button className="w-5 h-2 bg-primary rounded-2xl" />
+            {/* <button className="w-5 h-2 bg-primary rounded-2xl" /> */}
           </div>
         </div>
       </div>

--- a/packages/web/src/components/features/pages/mountain/CourseDetailBottomSheetSection/index.tsx
+++ b/packages/web/src/components/features/pages/mountain/CourseDetailBottomSheetSection/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-key */
 "use client";
 
 import useGetCourseDetails from "@hooks/feature/course/useGetCourseDetails";


### PR DESCRIPTION
- #63

## 주요 변경 사항

더 이상 사용하지 않는 코스 상세 페이지의 버튼을 제거하였습니다.

before.
<div align="center">
<img width="25%"  alt="Image" src="https://github.com/user-attachments/assets/4cbd554d-7d1d-491c-a0d1-9923a5407369" />
</div>

after.
<div align="center">
<img width="25%" alt="image" src="https://github.com/user-attachments/assets/95a5f943-4f8a-41cb-ac84-f4a2afe26f64" />
</div>


## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 코스 날씨 정보 섹션에서 불필요한 버튼 UI 요소를 제거했습니다.

* **코드 정리**
  * 산악 코스 상세 페이지에서 개발자 주석을 제거하여 코드베이스를 간결하게 정리했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->