### PR TITLE
[FEAT] 상세 신고 이후 신고 완료 모달이 뜨도록 수정

### DIFF
--- a/mock/mockoon_apis.json
+++ b/mock/mockoon_apis.json
@@ -241,7 +241,7 @@
       "responses": [
         {
           "uuid": "1e68ae8f-68d5-4105-a592-d378537ce667",
-          "body": "\n{\n\t\t\"data\" : {\n\t\t\turi : \"https://accounts.kakao.com/login/?continue=https%3A%2F%2Fkauth.kakao.com%2Foauth%2Fauthorize%3Fclient_id%3Dadf1cfad349f0843a6920c411c3005c2%26redirect_uri%3Dhttps%253A%252F%252Fapi.econo.soop.euichan.com%253A8080%252Fapi%252Fv1%252Foauth%252Fkakao%252Fcallback%26response_type%3Dcode%26through_account%3Dtrue#login\"\n\t\t}\n\t\t\"status\" : \"success\"\n}\n\n",
+          "body": "\n{\n\t\t\"data\" : {\n\t\t\turi : \"http://localhost:3000/social-login-loading?accessToken=eyJhbGciOiJIUzI1NiJ9.eyJpZCI6OSwiaWF0IjoxNzY4MjkyNTkwLCJleHAiOjE3Njk1MDIxOTB9.N3gkQUN5RnClvmlK5fhRQGuMLoClYzBCGUKVQJ3t6a0&refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJpZCI6OSwiaWF0IjoxNzY4MjkyNTkwLCJleHAiOjE3Njk1MDIxOTB9.mZpNyho0IzBBrmSqGmVPrlHF4yJjtnGWJK1AY9BmKDo&expiredTime=1769502190632\"\n\t\t}\n\t\t\"status\" : \"success\"\n}\n\n",
           "latency": 0,
           "statusCode": 301,
           "label": "",

--- a/packages/app/src/components/feature/widget/KakaoLoginButton/index.tsx
+++ b/packages/app/src/components/feature/widget/KakaoLoginButton/index.tsx
@@ -1,19 +1,11 @@
 import styled from "@emotion/native";
-import useCheckEnvironment from "@hooks/feature/env/useCheckEnvironment";
 import DefaultButton from "@shared/ui/buttons/DefaultButton";
 import { KakaoSVG } from "@shared/ui/Icons";
 import { router } from "expo-router";
 import { useCallback } from "react";
 
 const KakaoLoginButton = () => {
-  const { isMockServer } = useCheckEnvironment();
-
   const handleKakaoLogin = useCallback(() => {
-    if (isMockServer) {
-      router.dismissAll();
-      router.replace("/(tabs)/home");
-      return;
-    }
     router.push({
       pathname: "/loginModal",
       params: {

--- a/packages/app/src/hooks/feature/sms/useDetailReportSMS/index.ts
+++ b/packages/app/src/hooks/feature/sms/useDetailReportSMS/index.ts
@@ -1,4 +1,5 @@
 import useSMS from "@hooks/common/useSMS";
+import useReportResultModal from "@hooks/feature/modal/useReportResultModal";
 
 const REPORT_MESSAGE = ({
   lng,
@@ -39,6 +40,8 @@ const useDetailReportSMS = ({
   attachment,
   enable,
 }: UseDetailReportSMSProps) => {
+  const { showReportResult } = useReportResultModal();
+
   if (!REPORT_NUMBER) {
     throw new Error("신고하기 번호가 설정되지 않았습니다.");
   }
@@ -58,6 +61,7 @@ const useDetailReportSMS = ({
           attachments: attachments,
         }
       : undefined,
+    onSuccess: showReportResult,
   });
 };
 

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -1,5 +1,14 @@
+import ROUTE from "@/constants/route";
 import KakaoLoginSection from "@pages/login/KakaoLoginSection";
+import { redirect } from "next/navigation";
+
+const isMockServer = process.env.NEXT_PUBLIC_NODE_ENV === "development";
 
 export default function KakaoLoginPage() {
-  return <KakaoLoginSection />;
+  if (isMockServer)
+    redirect(
+      ROUTE.SOCIAL_LOGIN_LOADING +
+        "?accessToken=test&refreshToken=test&expiredTime=1769502190632",
+    );
+  return <>{!isMockServer && <KakaoLoginSection />}</>;
 }


### PR DESCRIPTION
- #65 

상세 신고 이후 신고 완료 모달이 뜨도록 수정하였습니다. 

<div align="center">
<img width="25%" alt="image" src="https://github.com/user-attachments/assets/fd53ad22-32cd-43b7-8a81-f98fe8598142" />
</div>

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * Mock 로그인 환경에서의 리다이렉트 동작 개선
  * 카카오 로그인 라우팅 로직 최적화

* **New Features**
  * SMS 발송 완료 시 결과 모달 표시 추가

* **Refactor**
  * 환경 체크 로직 단순화 및 통합

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->