### PR TITLE
[FEAT] 이용 약관 페이지 약관 글 링크 연결 구현

### DIFF
--- a/packages/app/assets/icons/Chevron_Left.svg
+++ b/packages/app/assets/icons/Chevron_Left.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.25 7.5L18.75 15L11.25 22.5" stroke="#41956A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -48,6 +48,12 @@ export default function RootLayout() {
                     }}
                   />
                   <Stack.Screen
+                    name="webModal"
+                    options={{
+                      presentation: "modal",
+                    }}
+                  />
+                  <Stack.Screen
                     name="report"
                     options={{
                       animation: "fade",

--- a/packages/app/src/app/onboarding/terms.tsx
+++ b/packages/app/src/app/onboarding/terms.tsx
@@ -11,7 +11,7 @@ const TermsScreen = () => {
       <TermsHeaderSection />
       <Spacing size={32} />
       <TermsDescriptionSection />
-      <Spacing size={20} />
+      <Spacing size={28} />
       <TermListSection />
     </ScreenContainer>
   );

--- a/packages/app/src/app/webModal/[uri].tsx
+++ b/packages/app/src/app/webModal/[uri].tsx
@@ -1,0 +1,47 @@
+import ScreenContainer from "@components/common/shared/layout/Screen";
+import {
+  DISABLED_PINCH_GESTURE,
+  DISABLED_SCROLL,
+  DISABLED_TEXT_SELECT,
+  INJECT_TOKEN,
+  SET_VIEWPORT_RATE,
+} from "@constants/webview";
+import { useTokenStore } from "@store/secureStorage/useTokenStore";
+import { useLocalSearchParams } from "expo-router";
+import { useMemo } from "react";
+import WebView from "react-native-webview";
+
+const WebviewScreen = () => {
+  const { accessToken, refreshToken } = useTokenStore();
+  const { uri } = useLocalSearchParams<{ uri: string }>();
+  const sourceUri = decodeURIComponent(uri);
+
+  const INJECTED_JAVASCRIPT = useMemo(
+    () =>
+      `${DISABLED_PINCH_GESTURE}${DISABLED_TEXT_SELECT}${DISABLED_SCROLL}${SET_VIEWPORT_RATE}${INJECT_TOKEN(accessToken ?? "", refreshToken ?? "")}`,
+    [accessToken, refreshToken],
+  );
+
+  return (
+    <ScreenContainer>
+      <WebView
+        source={{ uri: sourceUri }}
+        style={{ flex: 1 }}
+        injectedJavaScript={INJECTED_JAVASCRIPT}
+        onShouldStartLoadWithRequest={(request) => {
+          // 띄우고자 하는 페이지만 뜨도록 설정
+          if (
+            request.url.startsWith(sourceUri) ||
+            request.mainDocumentURL?.startsWith(sourceUri)
+          ) {
+            return true;
+          }
+
+          return false; //true로 해줘도 된다.
+        }}
+      />
+    </ScreenContainer>
+  );
+};
+
+export default WebviewScreen;

--- a/packages/app/src/components/common/shared/ui/Icons/index.tsx
+++ b/packages/app/src/components/common/shared/ui/Icons/index.tsx
@@ -4,6 +4,7 @@ export { default as RightArrowSVG } from "@assets/icons/Right_Arrow.svg";
 export { default as LeftArrowWithWhiteBgSVG } from "@assets/icons/Left_Arrow_Black.svg";
 export { default as BackArrow } from "@assets/icons/Back_Arrow.svg";
 export { default as BackButton } from "@assets/icons/Back_Button.svg";
+export { default as ChevronLeft } from "@assets/icons/Chevron_Left.svg";
 
 //image
 export { default as StarSVG } from "@assets/icons/Star.svg";

--- a/packages/app/src/components/feature/screens/terms/TermListItemCard/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermListItemCard/index.tsx
@@ -1,12 +1,16 @@
 import styled from "@emotion/native";
+import { ChevronLeft } from "@shared/ui/Icons";
 import Text from "@shared/ui/Text";
 import TriangleCheckbox from "@shared/ui/TriangleCheckbox";
+import { router } from "expo-router";
+import { Pressable } from "react-native";
 
 interface TermListItemCardProps {
   title: string;
   description?: string;
   content?: React.ReactNode;
   checked: boolean;
+  termLink?: string;
   onPress?: () => void;
 }
 
@@ -15,22 +19,36 @@ const TermListItemCard = ({
   description,
   content,
   checked,
+  termLink,
   onPress,
 }: TermListItemCardProps) => {
+  const openTermLink = () => {
+    if (!termLink) return;
+    router.push(`/webModal/${encodeURIComponent(termLink)}`);
+  };
+
   return (
     <ListContainer>
       <TriangleCheckbox checked={checked} onPress={onPress} />
-      <ListContentContainer>
-        <Text fontSize={20} fontWeight="normal" color="black">
-          {title}
-        </Text>
-        {description && (
-          <Text fontSize={12} fontWeight="normal" color="gray900">
-            {description}
+      <Pressable
+        onPress={openTermLink}
+        style={{ flex: 1, flexDirection: "row" }}
+      >
+        <ListContentContainer>
+          <Text fontSize={14} fontWeight="normal" color="black">
+            {title}
           </Text>
-        )}
-        {content && content}
-      </ListContentContainer>
+          {description && (
+            <Text fontSize={12} fontWeight="normal" color="gray900">
+              {description}
+            </Text>
+          )}
+          {content && content}
+          {/* </Pressable> */}
+        </ListContentContainer>
+        {termLink && <ChevronLeft />}
+        {/* <Pressable onPress={openTermLink}> */}
+      </Pressable>
     </ListContainer>
   );
 };

--- a/packages/app/src/components/feature/screens/terms/TermListSection/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermListSection/index.tsx
@@ -11,6 +11,7 @@ const TermListSection = () => {
   const [require2, setRequire2] = useState(false);
   const [require3, setRequire3] = useState(false);
   const [optional, setOptional] = useState(false);
+
   return (
     <>
       <Container>
@@ -19,10 +20,10 @@ const TermListSection = () => {
           content={
             <>
               <Spacing size={18} />
-              <Text fontSize={14} fontWeight="normal" color="gray900">
+              <Text fontSize={12} fontWeight="normal" color="gray900">
                 전체동의는 필수 및 선택정보에 대한 동의도
               </Text>
-              <Text fontSize={14} fontWeight="normal" color="gray900">
+              <Text fontSize={12} fontWeight="normal" color="gray900">
                 포함되어 있으며 개별적으로도 동의를 선택할 수 있습니다.
               </Text>
             </>
@@ -44,21 +45,25 @@ const TermListSection = () => {
         <TermListItemCard
           title="[필수] 이용약관 동의"
           checked={require1}
+          termLink="https://azure-fahrenheit-0af.notion.site/2025-12-30-2d9ec90d98fc808392e3fe653e745dfa?source=copy_link"
           onPress={() => setRequire1(!require1)}
         />
         <TermListItemCard
           title="[필수] 개인정보 및 민감정보 수집·이용 동의"
           checked={require2}
+          termLink="https://azure-fahrenheit-0af.notion.site/2025-12-30-2deec90d98fc80ee8c4cdcfc9cfeb23e?source=copy_link"
           onPress={() => setRequire2(!require2)}
         />
         <TermListItemCard
           title="[필수] 위치정보 수집·이용 동의"
           checked={require3}
+          termLink="https://azure-fahrenheit-0af.notion.site/2025-12-30-2deec90d98fc80a9acebe435e32b505a?source=copy_link"
           onPress={() => setRequire3(!require3)}
         />
         <TermListItemCard
           title="[선택] 광고성 정보 및 마케팅 활용 동의"
           checked={optional}
+          termLink="https://azure-fahrenheit-0af.notion.site/2deec90d98fc8013be97cec37885a786?source=copy_link"
           onPress={() => setOptional(!optional)}
         />
       </Container>

--- a/packages/app/src/components/feature/screens/terms/TermsDescriptionSection/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermsDescriptionSection/index.tsx
@@ -1,16 +1,19 @@
+import Spacing from "@components/common/shared/layout/Spacing";
 import styled from "@emotion/native";
 import Text from "@shared/ui/Text";
 
 const TermsDescriptionSection = () => {
   return (
     <Container>
-      <Text fontWeight="semibold" fontSize={30} color="primary">
+      <Text fontWeight="semibold" fontSize={20} color="primary">
         환영합니다!
       </Text>
-      <Text fontWeight="semibold" fontSize={30} color="primary">
+      <Spacing size={8} />
+      <Text fontWeight="semibold" fontSize={20} color="primary">
         아래 약관에 동의하시면
       </Text>
-      <Text fontWeight="semibold" fontSize={30} color="primary">
+      <Spacing size={8} />
+      <Text fontWeight="semibold" fontSize={20} color="primary">
         안전한 산행이 시작됩니다
       </Text>
     </Container>


### PR DESCRIPTION
- #71 

이용 약관 페이지에 실제 약관 글로 이동할 수 있도록 로직을 구현하였습니다. 
약관 화면의 텍스트 크기를 조정했습니다.
약관 설명 섹션의 시각적 여백을 개선했습니다.

## 주의사항

추가적으로 약관 글 링크를 코드단으로 관리하도록 하고있습니다.
이에 따라서 링크 주소가 변경된 경우 코드를 수정해야하는 문제가 발생할 수 있습니다. 
이에 따라서 해당 링크를 코드단에서 관리해야할지, 아니면 이를 환경 변수 등으로 관리해야할지 고민이 필요합니다.