### PR TITLE
[FEAT] 경로 이탈 모달 레이아웃 및 ui 수정

### DIFF
--- a/packages/app/src/hooks/feature/modal/useBreakwayAlertModal/index.tsx
+++ b/packages/app/src/hooks/feature/modal/useBreakwayAlertModal/index.tsx
@@ -27,7 +27,7 @@ const useBreakwayAlertModal = () => {
     };
   }, [isOpen]);
 
-  const showReportResult = () => {
+  const showBreakwayAlert = () => {
     if (isOpen) return;
     setIsOpen(true);
     openModal(<ModalComponent />, {
@@ -45,7 +45,7 @@ const useBreakwayAlertModal = () => {
     closeModal();
   };
 
-  return { showReportResult, closeAlertModal };
+  return { showBreakwayAlert, closeAlertModal };
 };
 
 // Modal Component
@@ -77,14 +77,16 @@ const OutsideContainer = styled.TouchableOpacity`
 const ModalContainer = styled.View`
   display: flex;
   text-align: center;
-  width: 300px;
+  align-items: center;
+  justify-content: center;
+  width: 320px;
   background-color: ${COLORS.mainWhite};
   border-radius: 12px;
 `;
 
 const Icon = styled.Image`
-  width: 64px;
-  height: 64px;
+  width: 52px;
+  height: 52px;
 `;
 
 const Title = styled.Text`

--- a/packages/app/src/hooks/feature/travel/useTravelCourse/index.ts
+++ b/packages/app/src/hooks/feature/travel/useTravelCourse/index.ts
@@ -50,7 +50,7 @@ const useTravelCourse = ({ mountainId, courseId }: UseTravelCourseProps) => {
   });
   const { showTravelEndToast } = useTravelEndToast();
   const { showTravelErrorToast } = useTravelErrorToast();
-  const { showReportResult, closeAlertModal } = useBreakwayAlertModal();
+  const { showBreakwayAlert, closeAlertModal } = useBreakwayAlertModal();
 
   // init
   useEffect(() => {
@@ -80,7 +80,7 @@ const useTravelCourse = ({ mountainId, courseId }: UseTravelCourseProps) => {
       setRemainTimeToStopover(remainTimeToStopover);
 
       // 경로 이탈한 경우
-      if (isDeviation) showReportResult();
+      if (isDeviation) showBreakwayAlert();
       else closeAlertModal();
 
       // 도착한 경우

--- a/packages/app/src/hooks/feature/travel/useTravelWithoutCourse/index.ts
+++ b/packages/app/src/hooks/feature/travel/useTravelWithoutCourse/index.ts
@@ -42,7 +42,7 @@ const useTravelWithoutCourse = () => {
   });
   const { showTravelEndToast } = useTravelEndToast();
   const { showTravelErrorToast } = useTravelErrorToast();
-  const { showReportResult, closeAlertModal } = useBreakwayAlertModal();
+  const { showBreakwayAlert, closeAlertModal } = useBreakwayAlertModal();
 
   // init
   useEffect(() => {
@@ -65,7 +65,7 @@ const useTravelWithoutCourse = () => {
       setDistance(travelDistance);
 
       // 경로 이탈한 경우
-      if (isDeviation) showReportResult();
+      if (isDeviation) showBreakwayAlert();
       else closeAlertModal();
 
       // 도착한 경우

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -61,6 +61,8 @@ const font = localFont({
   ],
 });
 
+const NODE_ENV = process.env.NODE_ENV;
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -77,6 +79,9 @@ export default function RootLayout({
             </ModalProvider>
           </StackLinkProvider>
         </TanstackQueryProvider>
+        {NODE_ENV === "development" && (
+          <script src="http://localhost:3002/devtools-client.js"></script>
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
- #83

경로 이탈 알림 모달의 함수명을 더 명확하게 변경하고, UI 스타일을 개선하였습니다. 또한 웹뷰 디버깅을 위한 개발 환경 설정을 추가하였습니다.

## 주요 변경사항

### 경로 이탈 알림 모달 함수명 개선

`useBreakwayAlertModal` 훅에서 반환하는 함수명을 `showReportResult`에서 `showBreakwayAlert`로 변경하였습니다. 기존 함수명은 신고 결과를 보여주는 것처럼 오해의 소지가 있어, 경로 이탈 알림을 표시한다는 의미를 명확히 전달하도록 수정하였습니다. 이에 따라 해당 함수를 사용하는 `useTravelCourse`와 `useTravelWithoutCourse` 훅에서도 변경된 함수명을 반영하였습니다.

### 경로 이탈 알림 모달 UI 스타일 개선

모달의 레이아웃과 아이콘 크기를 조정하였습니다. 모달 컨테이너의 너비를 300px에서 320px로 증가시키고, `align-items`와 `justify-content` 속성을 추가하여 중앙 정렬을 더욱 명확하게 하였습니다. 또한 아이콘 크기를 64px에서 52px로 축소하여 전체적인 UI 밸런스를 개선하였습니다.

### 웹뷰 디버깅 환경 설정 추가

개발 환경에서 웹뷰를 효과적으로 디버깅할 수 있도록 `devtools-client.js` 스크립트를 추가하였습니다. 이 스크립트는 `NODE_ENV`가 `development`일 때만 로드되어 프로덕션 환경에는 영향을 주지 않습니다.

## 리뷰 주의사항

- 경로 이탈 알림 모달의 함수명 변경이 모든 사용 위치에서 올바르게 반영되었는지 확인 부탁드립니다.
- 모달 UI 스타일 변경이 실제 디바이스에서 의도한 대로 표시되는지 확인이 필요합니다.
