### PR TITLE
[FEAT] 이용 약관 페이지에서 로그아웃 플로우 구현

### DIFF
--- a/packages/app/src/components/common/shared/ui/Header/index.tsx
+++ b/packages/app/src/components/common/shared/ui/Header/index.tsx
@@ -21,7 +21,7 @@ const Header = ({
 }: HeaderProps) => {
   return (
     <Container paddingBlock={paddingBlock} paddingInline={paddingInline}>
-      <HeaderItem>{headerLeft && <BackButton />}</HeaderItem>
+      <HeaderItem>{headerLeft && headerLeft}</HeaderItem>
       <HeaderItem>
         <Text textAlign="center" fontSize={18} fontWeight="semibold">
           {headerTitle}

--- a/packages/app/src/components/feature/screens/terms/TermsHeaderSection/index.tsx
+++ b/packages/app/src/components/feature/screens/terms/TermsHeaderSection/index.tsx
@@ -1,7 +1,10 @@
 import Header from "@shared/ui/Header";
+import LogoutWithBackButton from "@widget/LogoutWithBackButton";
 
 const TermsHeaderSection = () => {
-  return <Header headerTitle="이용 약관" headerLeft={false} />;
+  return (
+    <Header headerTitle="이용 약관" headerLeft={<LogoutWithBackButton />} />
+  );
 };
 
 export default TermsHeaderSection;

--- a/packages/app/src/components/feature/widget/LogoutWithBackButton/index.tsx
+++ b/packages/app/src/components/feature/widget/LogoutWithBackButton/index.tsx
@@ -1,0 +1,18 @@
+import useLogout from "@hooks/feature/authenticate/useLogout";
+import BackButtonUi from "@shared/ui/BackButtonUi";
+import { router } from "expo-router";
+import { useCallback } from "react";
+
+const LogoutWithBackButton = () => {
+  const { logout } = useLogout();
+
+  const handleBackPress = useCallback(() => {
+    logout().then(() => {
+      router.replace("/");
+    });
+  }, [logout]);
+
+  return <BackButtonUi onPress={handleBackPress} />;
+};
+
+export default LogoutWithBackButton;

--- a/packages/app/src/hooks/feature/authenticate/useLogout/index.ts
+++ b/packages/app/src/hooks/feature/authenticate/useLogout/index.ts
@@ -1,4 +1,4 @@
-import { useTokenStore } from "@/src/store/secureStorage/useTokenStore";
+import { useTokenStore } from "@store/secureStorage/useTokenStore";
 import { removeValueFromSecureStore } from "@utils/secureStore";
 
 const useLogout = () => {


### PR DESCRIPTION
## 주요 변경 사항

이용 약관 페이지에서 로그아웃 플로우를 구현하였습니다.

요구사항에 맞추어서 이용 약관 페이지의 헤더에 뒤로가기 버튼 UI를 추가하였습니다. 
해당 버튼을 누르면 로그아웃 및 "/" 홈 화면으로 이동하도록 라우팅을 하도록 구현하였습니다. 

<div align="center">
<img width="25%" src="https://github.com/user-attachments/assets/2c48cbd2-82f8-48c4-9164-53d2fd67eb11" />
</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 약관 화면에서 로그아웃 버튼 추가로 사용자 편의성 향상
  * 로그아웃 실행 후 홈화면으로 자동 이동

* **개선사항**
  * 헤더 컴포넌트의 좌측 영역을 맞춤형 콘텐츠로 유연하게 표시 가능하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->